### PR TITLE
Removing JHU mentions 

### DIFF
--- a/docs/module_details/day0.Rmd
+++ b/docs/module_details/day0.Rmd
@@ -58,8 +58,6 @@ Install the latest version of RStudio (Desktop):
 
 You can also visit the `RStudio` website, <https://posit.co/download/rstudio-desktop/>.
 
-If you are using a computer issued from Hopkins, you may need to work with the IT department in advance to do these installations.
-
 ## Installing `jhur` (optional)
 
 The instructor team has created a collection of code, called a "package", that will help get data into your programming environment quickly. Copy and paste the following into the console and hit "return" to run the code.
@@ -99,4 +97,3 @@ You should see some messages in the console, ending with `* DONE (jhur)` if the 
 [Homework 1 Drop Box](`r config::get("courseplus_dropboxes")`)
 
 **Note**: only people taking the course for credit must turn in the assignments. However, we will evaluate all submitted assignments in case others would like feedback on their work.
-

--- a/help.Rmd
+++ b/help.Rmd
@@ -73,12 +73,12 @@ Hit the "esc" key to restore your `>`, then fix/rerun your code.
 ***
 ## **When should I use quotes ("") or backticks (``)?**
 
-Check out our [Guide on when to use quotes or backticks](https://daseh.org//resources/quotes_vs_backticks.html).
+Check out our [Guide on when to use quotes or backticks](https://daseh.org/resources/quotes_vs_backticks.html).
 
 ***
 ## **How do I know when to use the `pull()` function, instead of just using `select()`?**
 
-Check out our [Guide on what functions require pulling values out first](https://daseh.org//resources/functions_for_vectors.html).
+Check out our [Guide on what functions require pulling values out first](https://daseh.org/resources/functions_for_vectors.html).
 
 <br><br><br>
 

--- a/help.Rmd
+++ b/help.Rmd
@@ -73,12 +73,12 @@ Hit the "esc" key to restore your `>`, then fix/rerun your code.
 ***
 ## **When should I use quotes ("") or backticks (``)?**
 
-Check out our [Guide on when to use quotes or backticks](https://jhudatascience.org/intro_to_r/resources/quotes_vs_backticks.html).
+Check out our [Guide on when to use quotes or backticks](https://daseh.org//resources/quotes_vs_backticks.html).
 
 ***
 ## **How do I know when to use the `pull()` function, instead of just using `select()`?**
 
-Check out our [Guide on what functions require pulling values out first](https://jhudatascience.org/intro_to_r/resources/functions_for_vectors.html).
+Check out our [Guide on what functions require pulling values out first](https://daseh.org//resources/functions_for_vectors.html).
 
 <br><br><br>
 

--- a/materials_schedule.Rmd
+++ b/materials_schedule.Rmd
@@ -30,11 +30,10 @@ source("scripts/utils.R")
 pander::pandoc.table(
   read_markdown("docs/_schedule_table.Rmd") %>%
     mutate(across(
-      .fns = ~ str_replace_all(., "\\./", "https://jhudatascience.org/intro_to_r/")
+      .fns = ~ str_replace_all(., "\\./", "https://hutchdatascience.org/DaSEH/")
     )),
   missing = "",
   split.tables = Inf,
   style = "rmarkdown"
 )
 ```
-

--- a/modules/Basic_R/Basic_R.Rmd
+++ b/modules/Basic_R/Basic_R.Rmd
@@ -279,7 +279,7 @@ x + c(1, 2, 3, 4)
 - Use the `c()` function to combine text/numbers/etc. into a vector
 - Use the `length()` function to determine number of elements
 
-💻 [Lab](https://daseh.org//modules/Basic_R/lab/Basic_R_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Basic_R/lab/Basic_R_Lab.Rmd)
 
 
 # Pause for Day 1
@@ -364,7 +364,7 @@ This tells you that `x` is a numeric vector and tells you the length.
 - Reassigning allows you to make changes "in place"
 - `str()` tells you a lot of information about an object in your environment
 
-💻 [Lab](https://daseh.org//modules/Basic_R/lab/Basic_R_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Basic_R/lab/Basic_R_Lab.Rmd)
 
 ## Useful functions to create vectors `seq()`
 
@@ -422,9 +422,9 @@ y
 
 ## Summary
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Basic R Lab](https://daseh.org//modules/Basic_R/lab/Basic_R_Lab.Rmd)
+💻 [Basic R Lab](https://daseh.org/modules/Basic_R/lab/Basic_R_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "30%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Basic_R/Basic_R.Rmd
+++ b/modules/Basic_R/Basic_R.Rmd
@@ -41,7 +41,7 @@ knitr::include_graphics("images/green_play_button.png")
 2^3
 ```
 
-Note: when you enter your command in the Console, R inherently thinks you want to print the result. 
+Note: when you enter your command in the Console, R inherently thinks you want to print the result.
 
 ## R as a calculator
 
@@ -49,7 +49,7 @@ Note: when you enter your command in the Console, R inherently thinks you want t
 - Try to play around with it:
     - +, -, /, * are add, subtract, divide and multiply
     - ^ or ** is power
-    - parentheses -- ( and ) -- work with order of operations 
+    - parentheses -- ( and ) -- work with order of operations
     - %% finds the remainder
 
 ## R as a calculator
@@ -174,7 +174,7 @@ z <- 3,000
 ## TROUBLESHOOTING: Complete the statement
 
 ```{r error = TRUE}
-10 / 
+10 /
 ```
 
 `+` indicates an incomplete statement. Hit "esc" to clear and bring back the `>`.
@@ -198,7 +198,7 @@ name
 
 ## The 'combine' function `c()`
 
-The function `c()` collects/combines/joins single R objects into a vector of R objects. It is mostly used for creating vectors of numbers, character strings, and other data types. 
+The function `c()` collects/combines/joins single R objects into a vector of R objects. It is mostly used for creating vectors of numbers, character strings, and other data types.
 
 ```{r assign3a}
 x <- c(1, 4, 6, 8)
@@ -279,7 +279,7 @@ x + c(1, 2, 3, 4)
 - Use the `c()` function to combine text/numbers/etc. into a vector
 - Use the `length()` function to determine number of elements
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Basic_R/lab/Basic_R_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Basic_R/lab/Basic_R_Lab.Rmd)
 
 
 # Pause for Day 1
@@ -364,7 +364,7 @@ This tells you that `x` is a numeric vector and tells you the length.
 - Reassigning allows you to make changes "in place"
 - `str()` tells you a lot of information about an object in your environment
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Basic_R/lab/Basic_R_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Basic_R/lab/Basic_R_Lab.Rmd)
 
 ## Useful functions to create vectors `seq()`
 
@@ -382,7 +382,7 @@ seq(from = -5, to = 5, length.out = 10)
 
 ## Useful functions to create vectors `rep()`
 
-For character: `rep()` can create very long vectors. 
+For character: `rep()` can create very long vectors.
 Works for creating character and numeric vectors.
 
 The `each` argument specifies how many of each item you want repeated.
@@ -402,13 +402,13 @@ rep(c("black", "white"), each = 2, times = 2)
  The `x` argument specifies what you are sampling from.
  The `size` argument specifies how many values there should be.
  The `replace` argument specifies if values should be replaced or not.
- 
+
 ```{r}
 seq_hun <- seq(from = 0, to = 100, by = 1)
 seq_hun
 y <- sample(x = seq_hun, size = 5, replace = TRUE)
 y
-``` 
+```
 
 ## Summary
 
@@ -422,9 +422,9 @@ y
 
 ## Summary
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Basic R Lab](https://jhudatascience.org/intro_to_r/modules/Basic_R/lab/Basic_R_Lab.Rmd)
+💻 [Basic R Lab](https://daseh.org//modules/Basic_R/lab/Basic_R_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "30%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Classes/Data_Classes.Rmd
+++ b/modules/Data_Classes/Data_Classes.Rmd
@@ -402,9 +402,9 @@ circ %>% mutate(year = year(date_formatted)) %>%
 
 ## Lab Part 1
 
-🏠 [Class Website](https://daseh.org//) 
+🏠 [Class Website](https://daseh.org/) 
 
-💻 [Lab](https://daseh.org//modules//Data_Classes/lab/Data_Classes_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules//Data_Classes/lab/Data_Classes_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Classes/Data_Classes.Rmd
+++ b/modules/Data_Classes/Data_Classes.Rmd
@@ -402,9 +402,9 @@ circ %>% mutate(year = year(date_formatted)) %>%
 
 ## Lab Part 1
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/) 
+🏠 [Class Website](https://daseh.org//) 
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules//Data_Classes/lab/Data_Classes_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules//Data_Classes/lab/Data_Classes_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Classes/lab/Data_Classes_Lab.Rmd
+++ b/modules/Data_Classes/lab/Data_Classes_Lab.Rmd
@@ -68,7 +68,7 @@ Read in the Charm City Circulator data using `read_circulator()` function from `
 
 ```{r}
 circ <- read_circulator()
-circ <- read_csv(file = "http://jhudatascience.org/intro_to_r/data/Charm_City_Circulator_Ridership.csv")
+circ <- read_csv(file = "https://daseh.org/data/Charm_City_Circulator_Ridership.csv")
 ```
 
 Use the `str()` function to take a look at the data and learn about the column types.

--- a/modules/Data_Classes/lab/Data_Classes_Lab_Key.Rmd
+++ b/modules/Data_Classes/lab/Data_Classes_Lab_Key.Rmd
@@ -73,7 +73,7 @@ Read in the Charm City Circulator data using `read_circulator()` function from `
 
 ```{r}
 circ <- read_circulator()
-circ <- read_csv(file = "http://jhudatascience.org/intro_to_r/data/Charm_City_Circulator_Ridership.csv")
+circ <- read_csv(file = "https://daseh.org/data/Charm_City_Circulator_Ridership.csv")
 ```
 
 Use the `str()` function to take a look at the data and learn about the column types.

--- a/modules/Data_Cleaning/Data_Cleaning.Rmd
+++ b/modules/Data_Cleaning/Data_Cleaning.Rmd
@@ -28,7 +28,7 @@ library(emoji)
   - combine with `mutate()` to add column
 - `summarize()` with `n()` gives the count (NAs included) 
 
-📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-4.pdf)
+📃[Cheatsheet](https://daseh.org/modules/cheatsheets/Day-4.pdf)
 
 ## Recap on data classes
 
@@ -42,7 +42,7 @@ library(emoji)
 - Dates can be handled with the `lubridate` package
 - Make sure you choose the right function for the way the date is formatted!
 
-    📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-4.pdf)
+    📃[Cheatsheet](https://daseh.org/modules/cheatsheets/Day-4.pdf)
 
 ## Data Cleaning {.emphasized}
 
@@ -377,8 +377,8 @@ knitr::include_graphics("images/debug.png")
 
 ## Lab Part 1
 
-🏠 [Class Website](https://daseh.org//)    
-💻[Lab](https://daseh.org//modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd)
+🏠 [Class Website](https://daseh.org/)    
+💻[Lab](https://daseh.org/modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd)
 
 
 
@@ -781,8 +781,8 @@ knitr::include_graphics("images/case_when.png")
 
 ## Lab Part 2
 
-🏠 [Class Website](https://daseh.org//)    
-💻[Lab](https://daseh.org//modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd)
+🏠 [Class Website](https://daseh.org/)    
+💻[Lab](https://daseh.org/modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Cleaning/Data_Cleaning.Rmd
+++ b/modules/Data_Cleaning/Data_Cleaning.Rmd
@@ -28,7 +28,7 @@ library(emoji)
   - combine with `mutate()` to add column
 - `summarize()` with `n()` gives the count (NAs included) 
 
-📃[Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-4.pdf)
+📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-4.pdf)
 
 ## Recap on data classes
 
@@ -42,7 +42,7 @@ library(emoji)
 - Dates can be handled with the `lubridate` package
 - Make sure you choose the right function for the way the date is formatted!
 
-    📃[Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-4.pdf)
+    📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-4.pdf)
 
 ## Data Cleaning {.emphasized}
 
@@ -377,8 +377,8 @@ knitr::include_graphics("images/debug.png")
 
 ## Lab Part 1
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)    
-💻[Lab](https://jhudatascience.org/intro_to_r/modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd)
+🏠 [Class Website](https://daseh.org//)    
+💻[Lab](https://daseh.org//modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd)
 
 
 
@@ -781,8 +781,8 @@ knitr::include_graphics("images/case_when.png")
 
 ## Lab Part 2
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)    
-💻[Lab](https://jhudatascience.org/intro_to_r/modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd)
+🏠 [Class Website](https://daseh.org//)    
+💻[Lab](https://daseh.org//modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Cleaning/Data_Cleaning.Rmd
+++ b/modules/Data_Cleaning/Data_Cleaning.Rmd
@@ -108,7 +108,7 @@ Check the values for your variables, are they what you expect?
 ```{r, message=FALSE}
 library(jhur)
 bike <- read_csv(file =
-    "http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv")
+    "https://daseh.org/data/Bike_Lanes.csv")
 bike %>% count(subType)
 ```
 
@@ -414,7 +414,7 @@ data_diet <- tibble(Diet = rep(c("A", "B", "B"),
 ## Reading in the data if it were an excel sheet
 Data is also here: 
 
-http://jhudatascience.org/intro_to_r/data/cleaning_diet_data.xlsx
+https://daseh.org/data/cleaning_diet_data.xlsx
 
 ```{r}
 library(readxl)

--- a/modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd
+++ b/modules/Data_Cleaning/lab/Data_Cleaning_Lab.Rmd
@@ -12,7 +12,7 @@ editor_options:
 Bike Lanes Dataset: BikeBaltimore is the Department of Transportation's bike program. 
 The data is from http://data.baltimorecity.gov/Transportation/Bike-Lanes/xzfj-gyms
 
-You can Download as a CSV in your current working directory.  Note its also available at: 	http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv 
+You can Download as a CSV in your current working directory.  Note its also available at: 	https://daseh.org/data/Bike_Lanes.csv 
 
 ```{r}
 library(readr)
@@ -31,7 +31,7 @@ Read in the bike data, you can use the URL or download the data.
 Bike Lanes Dataset: BikeBaltimore is the Department of Transportation's bike program. 
 The data is from http://data.baltimorecity.gov/Transportation/Bike-Lanes/xzfj-gyms
 
-You can Download as a CSV in your current working directory.  Note its also available at: 	http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv 
+You can Download as a CSV in your current working directory.  Note its also available at: 	https://daseh.org/data/Bike_Lanes.csv 
 
 ```{r 1.0response}
 

--- a/modules/Data_Cleaning/lab/Data_Cleaning_Lab_Key.Rmd
+++ b/modules/Data_Cleaning/lab/Data_Cleaning_Lab_Key.Rmd
@@ -12,7 +12,7 @@ editor_options:
 Bike Lanes Dataset: BikeBaltimore is the Department of Transportation's bike program. 
 The data is from http://data.baltimorecity.gov/Transportation/Bike-Lanes/xzfj-gyms
 
-You can Download as a CSV in your current working directory.  Note its also available at: 	http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv 
+You can Download as a CSV in your current working directory.  Note its also available at: 	https://daseh.org/data/Bike_Lanes.csv 
 
 ```{r}
 library(readr)
@@ -31,10 +31,10 @@ Read in the bike data, you can use the URL or download the data.
 Bike Lanes Dataset: BikeBaltimore is the Department of Transportation's bike program. 
 The data is from http://data.baltimorecity.gov/Transportation/Bike-Lanes/xzfj-gyms
 
-You can Download as a CSV in your current working directory.  Note its also available at: 	http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv 
+You can Download as a CSV in your current working directory.  Note its also available at: 	https://daseh.org/data/Bike_Lanes.csv 
 
 ```{r 1.0response}
-bike <- read_csv(file = "http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv")
+bike <- read_csv(file = "https://daseh.org/data/Bike_Lanes.csv")
 ```
 
 ### 1.1

--- a/modules/Data_Input/Data_Input.Rmd
+++ b/modules/Data_Input/Data_Input.Rmd
@@ -181,9 +181,9 @@ Importing data:
 
 Review the process: [`https://youtu.be/LEkNfJgpunQ`](https://youtu.be/LEkNfJgpunQ)
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Data Input Lab](https://jhudatascience.org/intro_to_r/modules/Data_Input/lab/Data_Input_Lab.Rmd)
+💻 [Data Input Lab](https://daseh.org//modules/Data_Input/lab/Data_Input_Lab.Rmd)
 
 
 # Part 2: Getting data into R (directly)
@@ -506,9 +506,9 @@ Don't forget to use `<-` to assign your data to an object!
 
 ## Lab Part 2
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Data Input Lab](https://jhudatascience.org/intro_to_r/modules/Data_Input/lab/Data_Input_Lab.Rmd)
+💻 [Data Input Lab](https://daseh.org//modules/Data_Input/lab/Data_Input_Lab.Rmd)
 
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}

--- a/modules/Data_Input/Data_Input.Rmd
+++ b/modules/Data_Input/Data_Input.Rmd
@@ -19,7 +19,7 @@ pre { /* Code block - slightly smaller in this lecture */
 </style>
 
 
-## Outline 
+## Outline
 
 * Part 0: A little bit of set up!
 * Part 1: reading in manually (point and click)
@@ -74,7 +74,7 @@ knitr::include_graphics("images/Data_Input_new_project_details.png")
 
 ## New R Project
 
-You now have a new R Project folder on your Desktop! 
+You now have a new R Project folder on your Desktop!
 
 Make sure you add any scripts or data files to this folder as we go through today's lesson. This will make sure R is able to "find" your files.
 
@@ -117,7 +117,7 @@ Youth Tobacco Survey (YTS) dataset:
 -  `>` File
 -  `>` Import Dataset
 -  `>` From Text (`readr`)
--  `>` paste the url (http://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv)
+-  `>` paste the url (https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv)
 -  `>` click "Update" and "Import"
 
 
@@ -176,7 +176,7 @@ Cons: obscures some of what's happening, others will have difficulty running you
 Importing data:
 
 -  File `>` Import Dataset `>` From Text (`readr`)
--  Paste the url (http://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv)
+-  Paste the url (https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv)
 -  Click "Update" and "Import"
 
 Review the process: [`https://youtu.be/LEkNfJgpunQ`](https://youtu.be/LEkNfJgpunQ)
@@ -188,13 +188,13 @@ Review the process: [`https://youtu.be/LEkNfJgpunQ`](https://youtu.be/LEkNfJgpun
 
 # Part 2: Getting data into R (directly)
 
-## Data Input: Read in Directly 
+## Data Input: Read in Directly
 
 ```{r message = FALSE}
 # load library `readr` that contains function `read_csv`
 library(readr)
 dat <- read_csv(
-  file = "http://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv"
+  file = "https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv"
 )
 
 # `head` displays first few rows of a data frame. `tail()` works the same way.
@@ -205,22 +205,22 @@ head(dat, n = 5)
 
 ```{r message = FALSE}
 dat <- read_csv(
-  file = "http://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv"
+  file = "https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv"
 )
 # EQUIVALENT TO
 dat <- read_csv(
-  "http://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv"
+  "https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv"
 )
 ```
 
 
-## Data Input: Read in Directly 
+## Data Input: Read in Directly
 
 `read_csv()` needs an argument `file =`.
 
 -  `file` is the path to your file, **in quotation marks**
 -  can be path to a file on a website (URL)
--  can be **path** in your local computer -- absolute file path or relative file path 
+-  can be **path** in your local computer -- absolute file path or relative file path
 
 ```{r, eval = FALSE}
 # Examples
@@ -246,7 +246,7 @@ knitr::include_graphics("images/Data_Input_where_are_the_files.gif")
 
 When you set up an R Project, R looks for files in that folder.
 
-Luckily, we already set up an R Project! 
+Luckily, we already set up an R Project!
 
 Move downloaded files into the R Project folder.
 
@@ -277,7 +277,7 @@ dat <- read_csv(file = "Youth_Tobacco_Survey_YTS_Data.csv")
 
 When we create an R Project, we establish the **working directory**.
 
-Working directory is a folder (directory) that RStudio assumes "you are working in". 
+Working directory is a folder (directory) that RStudio assumes "you are working in".
 
 It's where R looks for files.
 
@@ -329,8 +329,8 @@ knitr::include_graphics("images/Data_Input_View_data.png")
 
 `read_delim()` needs path to your file and **file's delimiter**, will return a tibble
 
--  `file` is the path to your file, in quotes 
--  `delim` is what separates the fields within a record 
+-  `file` is the path to your file, in quotes
+-  `delim` is what separates the fields within a record
 
 ```{r, eval = FALSE}
 ## Examples
@@ -349,7 +349,7 @@ dat <- read_delim(file = "data.txt", delim = "|")
 ```{r}
 # Programmatically download
 download.file(
-  url = "http://jhudatascience.org/intro_to_r/data/asthma.xlsx",
+  url = "https://daseh.org/data/asthma.xlsx",
   destfile = "asthma.xlsx",
   overwrite = TRUE,
   mode = "wb"
@@ -392,17 +392,17 @@ read_dta(file = "mtcars.dta")
 
 ## `read.csv` is * base R *
 
-There are also data importing functions provided in base R (rather than the `readr` package), like `read.delim()` and `read.csv()`. 
+There are also data importing functions provided in base R (rather than the `readr` package), like `read.delim()` and `read.csv()`.
 
-These functions have slightly different syntax for reading in data (e.g. `header` argument). 
+These functions have slightly different syntax for reading in data (e.g. `header` argument).
 
-However, while many online resources use the base R tools, the latest version of RStudio switched to use these new `readr` data import tools, so we will use them in the class for slides. They are also up to two times faster for reading in large datasets, and have a progress bar which is nice. 
+However, while many online resources use the base R tools, the latest version of RStudio switched to use these new `readr` data import tools, so we will use them in the class for slides. They are also up to two times faster for reading in large datasets, and have a progress bar which is nice.
 
 
 ## TROUBLESHOOTING: Common new user mistakes we have seen
 
 1.  **Working directory problems: trying to read files that R "can't find"**
-    - Path misspecification 
+    - Path misspecification
     - more on this shortly!
 2.  Typos (R is **case sensitive**, `x` and `X` are different)
     - RStudio helps with "tab completion"
@@ -464,7 +464,7 @@ setwd("/Users/avahoffman/Desktop")
 
 ## Other Useful Functions
 
-- The `str()` function can tell you about data/objects (different variables and their classes - more on this later). 
+- The `str()` function can tell you about data/objects (different variables and their classes - more on this later).
 - We will also discuss the `glimpse()` function later, which does something very similar.
 - `head()` shows first few rows
 - `tail()` shows the last few rows
@@ -480,10 +480,10 @@ here()
 
 `read_csv()` function from `readr` package:
 
-- comma delimited data 
+- comma delimited data
 - needs a file path to be provided
 - returns a tibble (data frame)
-  
+
 R Projects are a good way to keep your files organized and reduce headaches
 
 - Use `getwd()` to check your working directory, where R looks for your data files
@@ -498,7 +498,7 @@ Look at your data!
 
 Other file types
 
-- `readr` package: `read_delim()` for general delimited files 
+- `readr` package: `read_delim()` for general delimited files
 - `readxl` package: `read_excel()` for Excel files
 
 Don't forget to use `<-` to assign your data to an object!

--- a/modules/Data_Input/Data_Input.Rmd
+++ b/modules/Data_Input/Data_Input.Rmd
@@ -181,9 +181,9 @@ Importing data:
 
 Review the process: [`https://youtu.be/LEkNfJgpunQ`](https://youtu.be/LEkNfJgpunQ)
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Data Input Lab](https://daseh.org//modules/Data_Input/lab/Data_Input_Lab.Rmd)
+💻 [Data Input Lab](https://daseh.org/modules/Data_Input/lab/Data_Input_Lab.Rmd)
 
 
 # Part 2: Getting data into R (directly)
@@ -506,9 +506,9 @@ Don't forget to use `<-` to assign your data to an object!
 
 ## Lab Part 2
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Data Input Lab](https://daseh.org//modules/Data_Input/lab/Data_Input_Lab.Rmd)
+💻 [Data Input Lab](https://daseh.org/modules/Data_Input/lab/Data_Input_Lab.Rmd)
 
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}

--- a/modules/Data_Input/lab/Data_Input_Lab.Rmd
+++ b/modules/Data_Input/lab/Data_Input_Lab.Rmd
@@ -29,7 +29,7 @@ Set up your R Project. Once complete, confirm you have created a project folder.
 
 Use the manual import method (File > Import Dataset > From Text (`readr`)) to Read in SARS-CoV-2 vaccination data from this URL:
 
-https://daseh.org//data/vaccinations.csv. 
+https://daseh.org/data/vaccinations.csv. 
 
 You can learn more about how the data was collected here: https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-Jurisdi/unsk-b7fc
 
@@ -55,7 +55,7 @@ Preview the data by clicking the table button in the Environment. How many obser
 ### 2.1
 
 Read in SARS-CoV-2 vaccination data from URL 
-https://daseh.org//data/vaccinations.csv
+https://daseh.org/data/vaccinations.csv
 and assign it to an object named `vacc`. Use the code structure below.
 
 ```
@@ -80,11 +80,11 @@ If it is not installed, install it via: `RStudio --> Tools --> Install Packages`
 
 ### 2.3
 
-Download the dataset of asthma prevalence in the USA from: https://daseh.org//data/asthma.xlsx file to `asthma.xlsx` by running the following code chunk. This only downloads the file, it does NOT bring the file into R.
+Download the dataset of asthma prevalence in the USA from: https://daseh.org/data/asthma.xlsx file to `asthma.xlsx` by running the following code chunk. This only downloads the file, it does NOT bring the file into R.
 
 ```{r}
 download.file(
-  url = "https://daseh.org//data/asthma.xlsx",
+  url = "https://daseh.org/data/asthma.xlsx",
   destfile = "asthma.xlsx",
   overwrite = TRUE,
   mode = "wb"
@@ -109,7 +109,7 @@ Use the `read_excel()` function in the `readxl` package to read the `asthma.xlsx
 Run the following code - is there a problem? How do you know?
 
 ```{r}
-yts <- read_delim("https://daseh.org//data/Youth_Tobacco_Survey_YTS_Data.csv", delim = "\t")
+yts <- read_delim("https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv", delim = "\t")
 yts
 ```
 

--- a/modules/Data_Input/lab/Data_Input_Lab.Rmd
+++ b/modules/Data_Input/lab/Data_Input_Lab.Rmd
@@ -29,7 +29,7 @@ Set up your R Project. Once complete, confirm you have created a project folder.
 
 Use the manual import method (File > Import Dataset > From Text (`readr`)) to Read in SARS-CoV-2 vaccination data from this URL:
 
-https://jhudatascience.org/intro_to_r/data/vaccinations.csv. 
+https://daseh.org//data/vaccinations.csv. 
 
 You can learn more about how the data was collected here: https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-Jurisdi/unsk-b7fc
 
@@ -55,7 +55,7 @@ Preview the data by clicking the table button in the Environment. How many obser
 ### 2.1
 
 Read in SARS-CoV-2 vaccination data from URL 
-https://jhudatascience.org/intro_to_r/data/vaccinations.csv
+https://daseh.org//data/vaccinations.csv
 and assign it to an object named `vacc`. Use the code structure below.
 
 ```
@@ -80,11 +80,11 @@ If it is not installed, install it via: `RStudio --> Tools --> Install Packages`
 
 ### 2.3
 
-Download the dataset of asthma prevalence in the USA from: https://jhudatascience.org/intro_to_r/data/asthma.xlsx file to `asthma.xlsx` by running the following code chunk. This only downloads the file, it does NOT bring the file into R.
+Download the dataset of asthma prevalence in the USA from: https://daseh.org//data/asthma.xlsx file to `asthma.xlsx` by running the following code chunk. This only downloads the file, it does NOT bring the file into R.
 
 ```{r}
 download.file(
-  url = "https://jhudatascience.org/intro_to_r/data/asthma.xlsx",
+  url = "https://daseh.org//data/asthma.xlsx",
   destfile = "asthma.xlsx",
   overwrite = TRUE,
   mode = "wb"
@@ -109,7 +109,7 @@ Use the `read_excel()` function in the `readxl` package to read the `asthma.xlsx
 Run the following code - is there a problem? How do you know?
 
 ```{r}
-yts <- read_delim("https://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv", delim = "\t")
+yts <- read_delim("https://daseh.org//data/Youth_Tobacco_Survey_YTS_Data.csv", delim = "\t")
 yts
 ```
 

--- a/modules/Data_Input/lab/Data_Input_Lab_Key.Rmd
+++ b/modules/Data_Input/lab/Data_Input_Lab_Key.Rmd
@@ -29,7 +29,7 @@ Set up your R Project. Once complete, confirm you have created a project folder.
 
 Use the manual import method (File > Import Dataset > From Text (`readr`)) to Read in SARS-CoV-2 vaccination data from this URL:
 
-https://daseh.org//data/vaccinations.csv. 
+https://daseh.org/data/vaccinations.csv. 
 
 You can learn more about how the data was collected here: https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-Jurisdi/unsk-b7fc
 
@@ -55,7 +55,7 @@ Preview the data by clicking the table button in the Environment. How many obser
 ### 2.1
 
 Read in SARS-CoV-2 vaccination data from URL 
-https://daseh.org//data/vaccinations.csv
+https://daseh.org/data/vaccinations.csv
 and assign it to an object named `vacc`. Use the code structure below.
 
 ```
@@ -66,7 +66,7 @@ library(readr)
 
 ```{r 2.1response}
 library(readr)
-vacc <- read_csv(file = "https://daseh.org//data/vaccinations.csv")
+vacc <- read_csv(file = "https://daseh.org/data/vaccinations.csv")
 ```
 
 ### 2.2
@@ -81,11 +81,11 @@ library(readxl)
 
 ### 2.3
 
-Download the dataset of asthma prevalence in the USA from: https://daseh.org//data/asthma.xlsx file to `asthma.xlsx` by running the following code chunk. This only downloads the file, it does NOT bring the file into R.
+Download the dataset of asthma prevalence in the USA from: https://daseh.org/data/asthma.xlsx file to `asthma.xlsx` by running the following code chunk. This only downloads the file, it does NOT bring the file into R.
 
 ```{r}
 download.file(
-  url = "https://daseh.org//data/asthma.xlsx",
+  url = "https://daseh.org/data/asthma.xlsx",
   destfile = "asthma.xlsx",
   overwrite = TRUE,
   mode = "wb"
@@ -110,7 +110,7 @@ asthma <- read_excel(path = "asthma.xlsx")
 Run the following code - is there a problem? How do you know?
 
 ```{r}
-yts <- read_delim("https://daseh.org//data/Youth_Tobacco_Survey_YTS_Data.csv", delim = "\t")
+yts <- read_delim("https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv", delim = "\t")
 yts
 ```
 

--- a/modules/Data_Input/lab/Data_Input_Lab_Key.Rmd
+++ b/modules/Data_Input/lab/Data_Input_Lab_Key.Rmd
@@ -29,7 +29,7 @@ Set up your R Project. Once complete, confirm you have created a project folder.
 
 Use the manual import method (File > Import Dataset > From Text (`readr`)) to Read in SARS-CoV-2 vaccination data from this URL:
 
-https://jhudatascience.org/intro_to_r/data/vaccinations.csv. 
+https://daseh.org//data/vaccinations.csv. 
 
 You can learn more about how the data was collected here: https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-Jurisdi/unsk-b7fc
 
@@ -55,7 +55,7 @@ Preview the data by clicking the table button in the Environment. How many obser
 ### 2.1
 
 Read in SARS-CoV-2 vaccination data from URL 
-https://jhudatascience.org/intro_to_r/data/vaccinations.csv
+https://daseh.org//data/vaccinations.csv
 and assign it to an object named `vacc`. Use the code structure below.
 
 ```
@@ -66,7 +66,7 @@ library(readr)
 
 ```{r 2.1response}
 library(readr)
-vacc <- read_csv(file = "https://jhudatascience.org/intro_to_r/data/vaccinations.csv")
+vacc <- read_csv(file = "https://daseh.org//data/vaccinations.csv")
 ```
 
 ### 2.2
@@ -81,11 +81,11 @@ library(readxl)
 
 ### 2.3
 
-Download the dataset of asthma prevalence in the USA from: https://jhudatascience.org/intro_to_r/data/asthma.xlsx file to `asthma.xlsx` by running the following code chunk. This only downloads the file, it does NOT bring the file into R.
+Download the dataset of asthma prevalence in the USA from: https://daseh.org//data/asthma.xlsx file to `asthma.xlsx` by running the following code chunk. This only downloads the file, it does NOT bring the file into R.
 
 ```{r}
 download.file(
-  url = "https://jhudatascience.org/intro_to_r/data/asthma.xlsx",
+  url = "https://daseh.org//data/asthma.xlsx",
   destfile = "asthma.xlsx",
   overwrite = TRUE,
   mode = "wb"
@@ -110,7 +110,7 @@ asthma <- read_excel(path = "asthma.xlsx")
 Run the following code - is there a problem? How do you know?
 
 ```{r}
-yts <- read_delim("https://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv", delim = "\t")
+yts <- read_delim("https://daseh.org//data/Youth_Tobacco_Survey_YTS_Data.csv", delim = "\t")
 yts
 ```
 

--- a/modules/Data_Output/Data_Output.Rmd
+++ b/modules/Data_Output/Data_Output.Rmd
@@ -115,9 +115,9 @@ knitr::include_graphics(here::here("images/save_environment.png"))
 - `.rds` files can be handy for saving intermediate work
 - Can save environment (or subset) using `save()` and `save.image()`
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Data Output Lab](https://daseh.org//modules/Data_Output/lab/Data_Output_Lab.Rmd)
+💻 [Data Output Lab](https://daseh.org/modules/Data_Output/lab/Data_Output_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Output/Data_Output.Rmd
+++ b/modules/Data_Output/Data_Output.Rmd
@@ -115,9 +115,9 @@ knitr::include_graphics(here::here("images/save_environment.png"))
 - `.rds` files can be handy for saving intermediate work
 - Can save environment (or subset) using `save()` and `save.image()`
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Data Output Lab](https://jhudatascience.org/intro_to_r/modules/Data_Output/lab/Data_Output_Lab.Rmd)
+💻 [Data Output Lab](https://daseh.org//modules/Data_Output/lab/Data_Output_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Output/Data_Output.Rmd
+++ b/modules/Data_Output/Data_Output.Rmd
@@ -39,7 +39,7 @@ write_csv(x, file,
 ```
 
 ```{r, echo = FALSE}
-dat <- read_csv("http://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv")
+dat <- read_csv("https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv")
 ```
 
 ## Data Output

--- a/modules/Data_Output/lab/Data_Output_Lab.Rmd
+++ b/modules/Data_Output/lab/Data_Output_Lab.Rmd
@@ -14,7 +14,7 @@ Remember anything you type here can be "sent" to the console with Cmd-Enter (OS-
 ### 1.1
 
 Read in SARS-CoV-2 vaccination data from URL 
-http://jhudatascience.org/intro_to_r/data/vaccinations.csv
+https://daseh.org/data/vaccinations.csv
 and assign it to an object named `vacc`. 
 
 ```

--- a/modules/Data_Output/lab/Data_Output_Lab_Key.Rmd
+++ b/modules/Data_Output/lab/Data_Output_Lab_Key.Rmd
@@ -14,7 +14,7 @@ Remember anything you type here can be "sent" to the console with Cmd-Enter (OS-
 ### 1.1
 
 Read in SARS-CoV-2 vaccination data from URL 
-http://jhudatascience.org/intro_to_r/data/vaccinations.csv
+https://daseh.org/data/vaccinations.csv
 and assign it to an object named `vacc`. 
 
 ```
@@ -25,7 +25,7 @@ library(readr)
 
 ```{r 1.1response}
 library(tidyverse)
-vacc <- read_csv(file = "http://jhudatascience.org/intro_to_r/data/vaccinations.csv")
+vacc <- read_csv(file = "https://daseh.org/data/vaccinations.csv")
 ```
 
 ### 1.2

--- a/modules/Data_Summarization/Data_Summarization.Rmd
+++ b/modules/Data_Summarization/Data_Summarization.Rmd
@@ -32,7 +32,7 @@ pre { /* Code block - slightly smaller in this lecture */
 - remove a column: `select()` with `!` mark (`!col_name`)
 - you can do sequential steps: especially using pipes `%>%`
 
-📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-3.pdf)
+📃[Cheatsheet](https://daseh.org/modules/cheatsheets/Day-3.pdf)
 
 
 ## Another Cheatsheet
@@ -310,9 +310,9 @@ summary(tb)
 - `summary(x)`: quantile information
 - `summarize`: creates a summary table of columns of interest
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Lab](https://daseh.org//modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd)
 
 
 ## Youth Tobacco Survey
@@ -550,9 +550,9 @@ yts %>%
   - combine with `mutate()` to add column
 - `summarize()` with `n()` gives the count (NAs included) 
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Lab](https://daseh.org//modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Summarization/Data_Summarization.Rmd
+++ b/modules/Data_Summarization/Data_Summarization.Rmd
@@ -174,7 +174,7 @@ tb <- read_tb()
 ```
 
 <br>
-If not, download the `xlsx` file from http://jhudatascience.org/intro_to_r/data/tb_incidence.xlsx and read it in:
+If not, download the `xlsx` file from https://daseh.org/data/tb_incidence.xlsx and read it in:
 
 ```{r eval = FALSE}
 library(readxl)
@@ -318,7 +318,7 @@ summary(tb)
 ## Youth Tobacco Survey
 
 Here we will be using the Youth Tobacco Survey data:
-http://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv
+https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv
 
 ```{r}
 yts <- read_yts()

--- a/modules/Data_Summarization/Data_Summarization.Rmd
+++ b/modules/Data_Summarization/Data_Summarization.Rmd
@@ -32,7 +32,7 @@ pre { /* Code block - slightly smaller in this lecture */
 - remove a column: `select()` with `!` mark (`!col_name`)
 - you can do sequential steps: especially using pipes `%>%`
 
-📃[Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-3.pdf)
+📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-3.pdf)
 
 
 ## Another Cheatsheet
@@ -310,9 +310,9 @@ summary(tb)
 - `summary(x)`: quantile information
 - `summarize`: creates a summary table of columns of interest
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd)
 
 
 ## Youth Tobacco Survey
@@ -550,9 +550,9 @@ yts %>%
   - combine with `mutate()` to add column
 - `summarize()` with `n()` gives the count (NAs included) 
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd
+++ b/modules/Data_Summarization/lab/Data_Summarization_Lab.Rmd
@@ -16,7 +16,7 @@ Data used
 Bike Lanes Dataset: BikeBaltimore is the Department of Transportation's bike program. 
 The data is from http://data.baltimorecity.gov/Transportation/Bike-Lanes/xzfj-gyms
 
-You can Download as a CSV in your current working directory.  Note its also available at: 	http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv 
+You can Download as a CSV in your current working directory.  Note its also available at: 	https://daseh.org/data/Bike_Lanes.csv 
 
 ```{r, echo = TRUE, message=FALSE, error = FALSE}
 library(readr)
@@ -24,7 +24,7 @@ library(dplyr)
 library(tidyverse)
 library(jhur)
 
-bike <- read_csv(file = "http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv")
+bike <- read_csv(file = "https://daseh.org/data/Bike_Lanes.csv")
 ```
 
 or use 

--- a/modules/Data_Summarization/lab/Data_Summarization_Lab_Key.Rmd
+++ b/modules/Data_Summarization/lab/Data_Summarization_Lab_Key.Rmd
@@ -16,7 +16,7 @@ Data used
 Bike Lanes Dataset: BikeBaltimore is the Department of Transportation's bike program. 
 The data is from http://data.baltimorecity.gov/Transportation/Bike-Lanes/xzfj-gyms
 
-You can Download as a CSV in your current working directory.  Note its also available at: 	http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv 
+You can Download as a CSV in your current working directory.  Note its also available at: 	https://daseh.org/data/Bike_Lanes.csv 
 
 ```{r, echo = TRUE, message=FALSE, error = FALSE}
 library(readr)
@@ -24,7 +24,7 @@ library(dplyr)
 library(tidyverse)
 library(jhur)
 
-bike <- read_csv(file = "http://jhudatascience.org/intro_to_r/data/Bike_Lanes.csv")
+bike <- read_csv(file = "https://daseh.org/data/Bike_Lanes.csv")
 ```
 
 or use 

--- a/modules/Data_Visualization/Data_Visualization.Rmd
+++ b/modules/Data_Visualization/Data_Visualization.Rmd
@@ -30,7 +30,7 @@ library(emo)
     -   `values_from` specifies the old column name that contains new cell values\
 -   to merge/join data sets together need a variable in common - usually "id"
 
-📃[Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-6.pdf)
+📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-6.pdf)
 
 ## Recap continued
 
@@ -43,7 +43,7 @@ library(emo)
 -   `anti_join(x, y)` - all rows from `x` not in `y` keeping just columns from `x`.
 -   `esquisser()` function of the `esquisse` package can help make plot sketches
 
-📃[Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-6.pdf)
+📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-6.pdf)
 
 ## `esquisse` and `ggplot2`
 
@@ -482,8 +482,8 @@ Orange %>% ggplot(aes(x = circumference,
 
 ## Lab 1
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)\
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules//Data_Visualization/lab/Data_Visualization_Lab.Rmd)
+🏠 [Class Website](https://daseh.org//)\
+💻 [Lab](https://daseh.org//modules//Data_Visualization/lab/Data_Visualization_Lab.Rmd)
 
 ## theme() function:
 
@@ -962,8 +962,8 @@ Check out this [guide](https://jhudatascience.org/tidyversecourse/dataviz.html#m
 
 ## Lab 2
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)\
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules//Data_Visualization/lab/Data_Visualization_Lab.Rmd)
+🏠 [Class Website](https://daseh.org//)\
+💻 [Lab](https://daseh.org//modules//Data_Visualization/lab/Data_Visualization_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Data_Visualization/Data_Visualization.Rmd
+++ b/modules/Data_Visualization/Data_Visualization.Rmd
@@ -613,7 +613,7 @@ First, we will read in some data for the purpose of demonstration about food pri
 
 ```{r}
 food <- read_csv(
-  file = "http://jhudatascience.org/intro_to_r/data/food_price.csv")
+  file = "https://daseh.org/data/food_price.csv")
 ```
 
 ## Food data

--- a/modules/Data_Visualization/Data_Visualization.Rmd
+++ b/modules/Data_Visualization/Data_Visualization.Rmd
@@ -30,7 +30,7 @@ library(emo)
     -   `values_from` specifies the old column name that contains new cell values\
 -   to merge/join data sets together need a variable in common - usually "id"
 
-📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-6.pdf)
+📃[Cheatsheet](https://daseh.org/modules/cheatsheets/Day-6.pdf)
 
 ## Recap continued
 
@@ -43,7 +43,7 @@ library(emo)
 -   `anti_join(x, y)` - all rows from `x` not in `y` keeping just columns from `x`.
 -   `esquisser()` function of the `esquisse` package can help make plot sketches
 
-📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-6.pdf)
+📃[Cheatsheet](https://daseh.org/modules/cheatsheets/Day-6.pdf)
 
 ## `esquisse` and `ggplot2`
 
@@ -482,8 +482,8 @@ Orange %>% ggplot(aes(x = circumference,
 
 ## Lab 1
 
-🏠 [Class Website](https://daseh.org//)\
-💻 [Lab](https://daseh.org//modules//Data_Visualization/lab/Data_Visualization_Lab.Rmd)
+🏠 [Class Website](https://daseh.org/)\
+💻 [Lab](https://daseh.org/modules//Data_Visualization/lab/Data_Visualization_Lab.Rmd)
 
 ## theme() function:
 
@@ -962,8 +962,8 @@ Check out this [guide](https://jhudatascience.org/tidyversecourse/dataviz.html#m
 
 ## Lab 2
 
-🏠 [Class Website](https://daseh.org//)\
-💻 [Lab](https://daseh.org//modules//Data_Visualization/lab/Data_Visualization_Lab.Rmd)
+🏠 [Class Website](https://daseh.org/)\
+💻 [Lab](https://daseh.org/modules//Data_Visualization/lab/Data_Visualization_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Esquisse_Data_Visualization/Esquisse_Data_Visualization.Rmd
+++ b/modules/Esquisse_Data_Visualization/Esquisse_Data_Visualization.Rmd
@@ -190,9 +190,9 @@ esquisser(long_circ) # day as x, Boardings as y, Route as fill
 
 ## Lab
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Lab](https://daseh.org//modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Esquisse_Data_Visualization/Esquisse_Data_Visualization.Rmd
+++ b/modules/Esquisse_Data_Visualization/Esquisse_Data_Visualization.Rmd
@@ -190,9 +190,9 @@ esquisser(long_circ) # day as x, Boardings as y, Route as fill
 
 ## Lab
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab.Rmd
+++ b/modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab.Rmd
@@ -50,7 +50,7 @@ yts <- read_yts()
 tb <- read_tb()
 bike <- read_bike()
 circ <- read_circulator()
-vacc <- read_csv("http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv")
+vacc <- read_csv("https://daseh.org/data/USA_covid19_vaccinations.csv")
 ```
 
 ```{r P.1response}

--- a/modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab_Key.Rmd
+++ b/modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab_Key.Rmd
@@ -65,7 +65,7 @@ yts <- read_yts()
 tb <- read_tb()
 bike <- read_bike()
 circ <- read_circulator()
-vacc <- read_csv("http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv")
+vacc <- read_csv("https://daseh.org/data/USA_covid19_vaccinations.csv")
 ```
 
 ```{r P.1response}

--- a/modules/Factors/Factors.Rmd
+++ b/modules/Factors/Factors.Rmd
@@ -80,10 +80,10 @@ We will use data on student dropouts from the State of California during the 201
 
 To preserve school anonymity, "CDS_CODE" is used in place of the individual school's name.
 
-You can download the data from the JHU website here: http://jhudatascience.org/intro_to_r/data/dropouts.txt
+You can download the data from the DaSEH website here: https://daseh.org/data/dropouts.txt
 
 ```{r}
-dropouts <- read_delim("http://jhudatascience.org/intro_to_r/data/dropouts.txt", delim = "\t")
+dropouts <- read_delim("https://daseh.org/data/dropouts.txt", delim = "\t")
 dropouts
 ```
 
@@ -125,9 +125,9 @@ dropouts
 head(dropouts)
 ```
 
-Notice that `grade` is a `chr` variable. This indicates that the values are **character** strings. 
+Notice that `grade` is a `chr` variable. This indicates that the values are **character** strings.
 
-R does not realize that there is any order related to the `grade` values. It will assume that it is **alphabetical**. 
+R does not realize that there is any order related to the `grade` values. It will assume that it is **alphabetical**.
 
 However, we know that the order is: **freshman**, **sophomore**, **junior**, **senior**.
 
@@ -151,7 +151,7 @@ dropouts_subset %>%
   theme_bw(base_size = 16) # make all labels size 16
 ```
 
-OK this is very useful, but it is a bit difficult to read. We expect the values to be plotted by the order that we know, not by alphabetical order. 
+OK this is very useful, but it is a bit difficult to read. We expect the values to be plotted by the order that we know, not by alphabetical order.
 
 ## Change to factor
 
@@ -232,7 +232,7 @@ dropouts_fct %>%
 
 ## `forcats` for ordering{.smaller}
 
-What if we wanted to order `grade` by increasing `n_dropouts`? 
+What if we wanted to order `grade` by increasing `n_dropouts`?
 
 ```{r, fig.height= 3}
 library(forcats)
@@ -321,4 +321,3 @@ knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))
 ```
 
 Image by <a href="https://pixabay.com/users/geralt-9301/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=812226">Gerd Altmann</a> from <a href="https://pixabay.com//?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=812226">Pixabay</a>
-

--- a/modules/Factors/Factors.Rmd
+++ b/modules/Factors/Factors.Rmd
@@ -313,8 +313,8 @@ dropouts_fct %>%
 
 ## Lab
 
-🏠 [Class Website](https://daseh.org//)    
-💻 [Lab](https://daseh.org//modules//Factors/lab/Factors_Lab.Rmd)
+🏠 [Class Website](https://daseh.org/)    
+💻 [Lab](https://daseh.org/modules//Factors/lab/Factors_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Factors/Factors.Rmd
+++ b/modules/Factors/Factors.Rmd
@@ -313,8 +313,8 @@ dropouts_fct %>%
 
 ## Lab
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)    
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules//Factors/lab/Factors_Lab.Rmd)
+🏠 [Class Website](https://daseh.org//)    
+💻 [Lab](https://daseh.org//modules//Factors/lab/Factors_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Factors/lab/Factors_Lab_Key.Rmd
+++ b/modules/Factors/lab/Factors_Lab_Key.Rmd
@@ -20,7 +20,7 @@ Load the Youth Tobacco Survey data (using the `jhur` library function `read_yts(
 library(jhur)
 yts <- read_yts() %>% select(Sample_Size, Education, LocationAbbr)
 # Alt:
-# yts <- read_csv("http://jhudatascience.org/intro_to_r/data/Youth_Tobacco_Survey_YTS_Data.csv")
+# yts <- read_csv("https://daseh.org/data/Youth_Tobacco_Survey_YTS_Data.csv")
 ```
 
 ### 1.1

--- a/modules/Functions/Functions.Rmd
+++ b/modules/Functions/Functions.Rmd
@@ -253,9 +253,9 @@ clean_dataset(dataset = mtcars, col_name = "cyl")
 
 ## Lab Part 1
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)  
+🏠 [Class Website](https://daseh.org//)  
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Functions/lab/Functions_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Functions/lab/Functions_Lab.Rmd)
 
 
 # Functions on multiple columns
@@ -475,9 +475,9 @@ AQ_list %>% sapply(colMeans, na.rm = TRUE)
 
 ## Lab Part 2
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)  
+🏠 [Class Website](https://daseh.org//)  
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Functions/lab/Functions_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Functions/lab/Functions_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Functions/Functions.Rmd
+++ b/modules/Functions/Functions.Rmd
@@ -253,9 +253,9 @@ clean_dataset(dataset = mtcars, col_name = "cyl")
 
 ## Lab Part 1
 
-🏠 [Class Website](https://daseh.org//)  
+🏠 [Class Website](https://daseh.org/)  
 
-💻 [Lab](https://daseh.org//modules/Functions/lab/Functions_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Functions/lab/Functions_Lab.Rmd)
 
 
 # Functions on multiple columns
@@ -475,9 +475,9 @@ AQ_list %>% sapply(colMeans, na.rm = TRUE)
 
 ## Lab Part 2
 
-🏠 [Class Website](https://daseh.org//)  
+🏠 [Class Website](https://daseh.org/)  
 
-💻 [Lab](https://daseh.org//modules/Functions/lab/Functions_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Functions/lab/Functions_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Functions/lab/Functions_Lab.Rmd
+++ b/modules/Functions/lab/Functions_Lab.Rmd
@@ -70,7 +70,7 @@ Create a new number `b_num` that is not contained with `nums`. Use your updated 
 
 ### 2.1
 
-Read in the SARS-CoV-2 Vaccination data from http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv. Assign the data the name "vacc".
+Read in the SARS-CoV-2 Vaccination data from https://daseh.org/data/USA_covid19_vaccinations.csv. Assign the data the name "vacc".
 
 ```{r message = FALSE, label = '2.1response'}
 

--- a/modules/Functions/lab/Functions_Lab_Key.Rmd
+++ b/modules/Functions/lab/Functions_Lab_Key.Rmd
@@ -88,10 +88,10 @@ has_n(x = nums, n = b_num)
 
 ### 2.1
 
-Read in the SARS-CoV-2 Vaccination data from http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv. Assign the data the name "vacc".
+Read in the SARS-CoV-2 Vaccination data from https://daseh.org/data/USA_covid19_vaccinations.csv. Assign the data the name "vacc".
 
 ```{r message = FALSE, label = '2.1response'}
-vacc <- read_csv("http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv")
+vacc <- read_csv("https://daseh.org/data/USA_covid19_vaccinations.csv")
 # If downloaded
 # vacc <- read_csv("USA_covid19_vaccinations.csv")
 ```

--- a/modules/HW/homework2.Rmd
+++ b/modules/HW/homework2.Rmd
@@ -6,9 +6,9 @@ output:
 
 ### **Instructions**
 
-Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://jhudatascience.org/intro_to_r/syllabus.html#submitting-assignments.
+Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org//syllabus.html#submitting-assignments.
 
-Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://jhudatascience.org/intro_to_r/syllabus.html#grading.
+Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org//syllabus.html#grading.
 
 
 ```{r initiatePackages, message=FALSE}
@@ -58,14 +58,14 @@ library(tidyr)
 
 We will be working with a dataset from the "Kaggle" website, which hosts competitions for prediction and machine learning. More details on this dataset are here: https://www.kaggle.com/c/DontGetKicked/overview/background.
 
-5\. Bring the dataset into R. The dataset is located at: https://jhudatascience.org/intro_to_r/data/kaggleCarAuction.csv. You can use the link, download it, or use whatever method you like for getting the file. Once you get the file, read the dataset in using `read_csv()` and assign it the name `cars`.
+5\. Bring the dataset into R. The dataset is located at: https://daseh.org//data/kaggleCarAuction.csv. You can use the link, download it, or use whatever method you like for getting the file. Once you get the file, read the dataset in using `read_csv()` and assign it the name `cars`.
 
 ```{r 5response}
 
 ```
 
 
-6\. Import the data "dictionary" from https://jhudatascience.org/intro_to_r/data/Carvana_Data_Dictionary_formatted.txt. Use the `read_tsv()` function and assign it the name "key". 
+6\. Import the data "dictionary" from https://daseh.org//data/Carvana_Data_Dictionary_formatted.txt. Use the `read_tsv()` function and assign it the name "key". 
 
 ```{r 6response}
 

--- a/modules/HW/homework2.Rmd
+++ b/modules/HW/homework2.Rmd
@@ -6,9 +6,9 @@ output:
 
 ### **Instructions**
 
-Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org//syllabus.html#submitting-assignments.
+Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org/syllabus.html#submitting-assignments.
 
-Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org//syllabus.html#grading.
+Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org/syllabus.html#grading.
 
 
 ```{r initiatePackages, message=FALSE}
@@ -58,14 +58,14 @@ library(tidyr)
 
 We will be working with a dataset from the "Kaggle" website, which hosts competitions for prediction and machine learning. More details on this dataset are here: https://www.kaggle.com/c/DontGetKicked/overview/background.
 
-5\. Bring the dataset into R. The dataset is located at: https://daseh.org//data/kaggleCarAuction.csv. You can use the link, download it, or use whatever method you like for getting the file. Once you get the file, read the dataset in using `read_csv()` and assign it the name `cars`.
+5\. Bring the dataset into R. The dataset is located at: https://daseh.org/data/kaggleCarAuction.csv. You can use the link, download it, or use whatever method you like for getting the file. Once you get the file, read the dataset in using `read_csv()` and assign it the name `cars`.
 
 ```{r 5response}
 
 ```
 
 
-6\. Import the data "dictionary" from https://daseh.org//data/Carvana_Data_Dictionary_formatted.txt. Use the `read_tsv()` function and assign it the name "key". 
+6\. Import the data "dictionary" from https://daseh.org/data/Carvana_Data_Dictionary_formatted.txt. Use the `read_tsv()` function and assign it the name "key". 
 
 ```{r 6response}
 

--- a/modules/HW/homework2_Key.Rmd
+++ b/modules/HW/homework2_Key.Rmd
@@ -6,9 +6,9 @@ output:
 
 ### **Instructions**
 
-Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org//syllabus.html#submitting-assignments.
+Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org/syllabus.html#submitting-assignments.
 
-Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org//syllabus.html#grading.
+Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org/syllabus.html#grading.
 
 
 ```{r initiatePackages, message=FALSE}
@@ -60,18 +60,18 @@ class(me)
 
 We will be working with a dataset from the "Kaggle" website, which hosts competitions for prediction and machine learning. More details on this dataset are here: https://www.kaggle.com/c/DontGetKicked/overview/background.
 
-5\. Bring the dataset into R. The dataset is located at: https://daseh.org//data/kaggleCarAuction.csv. You can use the link, download it, or use whatever method you like for getting the file. Once you get the file, read the dataset in using `read_csv()` and assign it the name `cars`.
+5\. Bring the dataset into R. The dataset is located at: https://daseh.org/data/kaggleCarAuction.csv. You can use the link, download it, or use whatever method you like for getting the file. Once you get the file, read the dataset in using `read_csv()` and assign it the name `cars`.
 
 ```{r 5response}
-cars <- read_csv(file = "https://daseh.org//data/kaggleCarAuction.csv")
+cars <- read_csv(file = "https://daseh.org/data/kaggleCarAuction.csv")
 # OR
-cars <- read_csv("https://daseh.org//data/kaggleCarAuction.csv")
+cars <- read_csv("https://daseh.org/data/kaggleCarAuction.csv")
 # OR
-url <- "https://daseh.org//data/kaggleCarAuction.csv"
+url <- "https://daseh.org/data/kaggleCarAuction.csv"
 cars <- read_csv(file = url)
 # OR
 download.file(
-  url = "https://daseh.org//data/kaggleCarAuction.csv",
+  url = "https://daseh.org/data/kaggleCarAuction.csv",
   destfile = "cars_data.csv",
   overwrite = TRUE,
   mode = "wb"
@@ -80,13 +80,13 @@ cars <- read_csv(file = "cars_data.csv")
 ```
 
 
-6\. Import the data "dictionary" from https://daseh.org//data/Carvana_Data_Dictionary_formatted.txt. Use the `read_tsv()` function and assign it the name "key". 
+6\. Import the data "dictionary" from https://daseh.org/data/Carvana_Data_Dictionary_formatted.txt. Use the `read_tsv()` function and assign it the name "key". 
 
 ```{r 6response}
-key <- read_tsv(file = "https://daseh.org//data/Carvana_Data_Dictionary_formatted.txt")
+key <- read_tsv(file = "https://daseh.org/data/Carvana_Data_Dictionary_formatted.txt")
 # OR
 download.file(
-  url = "https://daseh.org//data/Carvana_Data_Dictionary_formatted.txt",
+  url = "https://daseh.org/data/Carvana_Data_Dictionary_formatted.txt",
   destfile = "dict.txt",
   overwrite = TRUE,
   mode = "wb"

--- a/modules/HW/homework2_Key.Rmd
+++ b/modules/HW/homework2_Key.Rmd
@@ -6,9 +6,9 @@ output:
 
 ### **Instructions**
 
-Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://jhudatascience.org/intro_to_r/syllabus.html#submitting-assignments.
+Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org//syllabus.html#submitting-assignments.
 
-Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://jhudatascience.org/intro_to_r/syllabus.html#grading.
+Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org//syllabus.html#grading.
 
 
 ```{r initiatePackages, message=FALSE}
@@ -60,18 +60,18 @@ class(me)
 
 We will be working with a dataset from the "Kaggle" website, which hosts competitions for prediction and machine learning. More details on this dataset are here: https://www.kaggle.com/c/DontGetKicked/overview/background.
 
-5\. Bring the dataset into R. The dataset is located at: https://jhudatascience.org/intro_to_r/data/kaggleCarAuction.csv. You can use the link, download it, or use whatever method you like for getting the file. Once you get the file, read the dataset in using `read_csv()` and assign it the name `cars`.
+5\. Bring the dataset into R. The dataset is located at: https://daseh.org//data/kaggleCarAuction.csv. You can use the link, download it, or use whatever method you like for getting the file. Once you get the file, read the dataset in using `read_csv()` and assign it the name `cars`.
 
 ```{r 5response}
-cars <- read_csv(file = "https://jhudatascience.org/intro_to_r/data/kaggleCarAuction.csv")
+cars <- read_csv(file = "https://daseh.org//data/kaggleCarAuction.csv")
 # OR
-cars <- read_csv("https://jhudatascience.org/intro_to_r/data/kaggleCarAuction.csv")
+cars <- read_csv("https://daseh.org//data/kaggleCarAuction.csv")
 # OR
-url <- "https://jhudatascience.org/intro_to_r/data/kaggleCarAuction.csv"
+url <- "https://daseh.org//data/kaggleCarAuction.csv"
 cars <- read_csv(file = url)
 # OR
 download.file(
-  url = "https://jhudatascience.org/intro_to_r/data/kaggleCarAuction.csv",
+  url = "https://daseh.org//data/kaggleCarAuction.csv",
   destfile = "cars_data.csv",
   overwrite = TRUE,
   mode = "wb"
@@ -80,13 +80,13 @@ cars <- read_csv(file = "cars_data.csv")
 ```
 
 
-6\. Import the data "dictionary" from https://jhudatascience.org/intro_to_r/data/Carvana_Data_Dictionary_formatted.txt. Use the `read_tsv()` function and assign it the name "key". 
+6\. Import the data "dictionary" from https://daseh.org//data/Carvana_Data_Dictionary_formatted.txt. Use the `read_tsv()` function and assign it the name "key". 
 
 ```{r 6response}
-key <- read_tsv(file = "https://jhudatascience.org/intro_to_r/data/Carvana_Data_Dictionary_formatted.txt")
+key <- read_tsv(file = "https://daseh.org//data/Carvana_Data_Dictionary_formatted.txt")
 # OR
 download.file(
-  url = "https://jhudatascience.org/intro_to_r/data/Carvana_Data_Dictionary_formatted.txt",
+  url = "https://daseh.org//data/Carvana_Data_Dictionary_formatted.txt",
   destfile = "dict.txt",
   overwrite = TRUE,
   mode = "wb"

--- a/modules/HW/homework3.Rmd
+++ b/modules/HW/homework3.Rmd
@@ -6,9 +6,9 @@ output:
 
 ### **Instructions**
 
-Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://jhudatascience.org/intro_to_r/syllabus.html#submitting-assignments.
+Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org//syllabus.html#submitting-assignments.
 
-Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://jhudatascience.org/intro_to_r/syllabus.html#grading.
+Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org//syllabus.html#grading.
 
 
 ```{r initiatePackages, message=FALSE}
@@ -25,7 +25,7 @@ library(tidyr)
 
 1\. Bring the following dataset into R. 
 
--  The dataset is located at: https://jhudatascience.org/intro_to_r/data/mortality.csv. 
+-  The dataset is located at: https://daseh.org//data/mortality.csv. 
 -  You can use the link, download it, or use whatever method you like for getting the file. 
 -  Once you get the file, read the dataset in using `read_csv()` and assign it the name "mort".
 
@@ -84,7 +84,7 @@ library(tidyr)
 
 8\. Bring an additional dataset into R. 
 
--  The dataset is tab-delimited and located at: https://jhudatascience.org/intro_to_r/data/country_pop.txt. 
+-  The dataset is tab-delimited and located at: https://daseh.org//data/country_pop.txt. 
 -  You can use the link, download it, or use whatever method you like for getting the file. 
 -  Once you get the file, read the dataset in using `read_tsv()` and assign it the name "pop".
 
@@ -154,7 +154,7 @@ library(tidyr)
 
 A\. Bring the following dataset into R. 
 
--  The dataset is located at: https://jhudatascience.org/intro_to_r/data/asthma.xlsx. 
+-  The dataset is located at: https://daseh.org//data/asthma.xlsx. 
 -  You should download the associated data.
 -  Once you get the file, read the dataset in using `read_excel()` from the `readxl` package and assign it the name "asthma".
 -  Read in the sheet named "Age Group (Years)".

--- a/modules/HW/homework3.Rmd
+++ b/modules/HW/homework3.Rmd
@@ -6,9 +6,9 @@ output:
 
 ### **Instructions**
 
-Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org//syllabus.html#submitting-assignments.
+Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org/syllabus.html#submitting-assignments.
 
-Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org//syllabus.html#grading.
+Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org/syllabus.html#grading.
 
 
 ```{r initiatePackages, message=FALSE}
@@ -25,7 +25,7 @@ library(tidyr)
 
 1\. Bring the following dataset into R. 
 
--  The dataset is located at: https://daseh.org//data/mortality.csv. 
+-  The dataset is located at: https://daseh.org/data/mortality.csv. 
 -  You can use the link, download it, or use whatever method you like for getting the file. 
 -  Once you get the file, read the dataset in using `read_csv()` and assign it the name "mort".
 
@@ -84,7 +84,7 @@ library(tidyr)
 
 8\. Bring an additional dataset into R. 
 
--  The dataset is tab-delimited and located at: https://daseh.org//data/country_pop.txt. 
+-  The dataset is tab-delimited and located at: https://daseh.org/data/country_pop.txt. 
 -  You can use the link, download it, or use whatever method you like for getting the file. 
 -  Once you get the file, read the dataset in using `read_tsv()` and assign it the name "pop".
 
@@ -154,7 +154,7 @@ library(tidyr)
 
 A\. Bring the following dataset into R. 
 
--  The dataset is located at: https://daseh.org//data/asthma.xlsx. 
+-  The dataset is located at: https://daseh.org/data/asthma.xlsx. 
 -  You should download the associated data.
 -  Once you get the file, read the dataset in using `read_excel()` from the `readxl` package and assign it the name "asthma".
 -  Read in the sheet named "Age Group (Years)".

--- a/modules/HW/homework3_Key.Rmd
+++ b/modules/HW/homework3_Key.Rmd
@@ -6,9 +6,9 @@ output:
 
 ### **Instructions**
 
-Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org//syllabus.html#submitting-assignments.
+Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org/syllabus.html#submitting-assignments.
 
-Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org//syllabus.html#grading.
+Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org/syllabus.html#grading.
 
 
 ```{r initiatePackages, message=FALSE}
@@ -25,12 +25,12 @@ library(tidyr)
 
 1\. Bring the following dataset into R. 
 
--  The dataset is located at: https://daseh.org//data/mortality.csv. 
+-  The dataset is located at: https://daseh.org/data/mortality.csv. 
 -  You can use the link, download it, or use whatever method you like for getting the file. 
 -  Once you get the file, read the dataset in using `read_csv()` and assign it the name "mort".
 
 ```{r 1response}
-mort <- read_csv("https://daseh.org//data/mortality.csv")
+mort <- read_csv("https://daseh.org/data/mortality.csv")
 ```
 
 
@@ -107,12 +107,12 @@ long <-
 
 8\. Bring an additional dataset into R. 
 
--  The dataset is tab-delimited and located at: https://daseh.org//data/country_pop.txt. 
+-  The dataset is tab-delimited and located at: https://daseh.org/data/country_pop.txt. 
 -  You can use the link, download it, or use whatever method you like for getting the file. 
 -  Once you get the file, read the dataset in using `read_tsv()` and assign it the name "pop".
 
 ```{r 8response}
-pop <- read_tsv("https://daseh.org//data/country_pop.txt")
+pop <- read_tsv("https://daseh.org/data/country_pop.txt")
 ```
 
 
@@ -202,7 +202,7 @@ joined %>%
 
 A\. Bring the following dataset into R. 
 
--  The dataset is located at: https://daseh.org//data/asthma.xlsx. 
+-  The dataset is located at: https://daseh.org/data/asthma.xlsx. 
 -  You should download the associated data.
 -  Once you get the file, read the dataset in using `read_excel()` from the `readxl` package and assign it the name "asthma".
 -  Read in the sheet named "Age Group (Years)".

--- a/modules/HW/homework3_Key.Rmd
+++ b/modules/HW/homework3_Key.Rmd
@@ -6,9 +6,9 @@ output:
 
 ### **Instructions**
 
-Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://jhudatascience.org/intro_to_r/syllabus.html#submitting-assignments.
+Completed homework should be submitted on CoursePlus as an **Rmd file**. Please see the course website for more information about submitting assignments: https://daseh.org//syllabus.html#submitting-assignments.
 
-Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://jhudatascience.org/intro_to_r/syllabus.html#grading.
+Homework will be graded for correct output, not code style. All assignments are due at the end of the course. Please see the course website for more information about grading: https://daseh.org//syllabus.html#grading.
 
 
 ```{r initiatePackages, message=FALSE}
@@ -25,12 +25,12 @@ library(tidyr)
 
 1\. Bring the following dataset into R. 
 
--  The dataset is located at: https://jhudatascience.org/intro_to_r/data/mortality.csv. 
+-  The dataset is located at: https://daseh.org//data/mortality.csv. 
 -  You can use the link, download it, or use whatever method you like for getting the file. 
 -  Once you get the file, read the dataset in using `read_csv()` and assign it the name "mort".
 
 ```{r 1response}
-mort <- read_csv("https://jhudatascience.org/intro_to_r/data/mortality.csv")
+mort <- read_csv("https://daseh.org//data/mortality.csv")
 ```
 
 
@@ -107,12 +107,12 @@ long <-
 
 8\. Bring an additional dataset into R. 
 
--  The dataset is tab-delimited and located at: https://jhudatascience.org/intro_to_r/data/country_pop.txt. 
+-  The dataset is tab-delimited and located at: https://daseh.org//data/country_pop.txt. 
 -  You can use the link, download it, or use whatever method you like for getting the file. 
 -  Once you get the file, read the dataset in using `read_tsv()` and assign it the name "pop".
 
 ```{r 8response}
-pop <- read_tsv("https://jhudatascience.org/intro_to_r/data/country_pop.txt")
+pop <- read_tsv("https://daseh.org//data/country_pop.txt")
 ```
 
 
@@ -202,7 +202,7 @@ joined %>%
 
 A\. Bring the following dataset into R. 
 
--  The dataset is located at: https://jhudatascience.org/intro_to_r/data/asthma.xlsx. 
+-  The dataset is located at: https://daseh.org//data/asthma.xlsx. 
 -  You should download the associated data.
 -  Once you get the file, read the dataset in using `read_excel()` from the `readxl` package and assign it the name "asthma".
 -  Read in the sheet named "Age Group (Years)".

--- a/modules/Intro/Intro.Rmd
+++ b/modules/Intro/Intro.Rmd
@@ -4,7 +4,7 @@ output:
   ioslides_presentation:
     css: ../../docs/styles.css
     widescreen: yes
---- 
+---
 
 ```{r, echo = FALSE}
 library(knitr)
@@ -24,14 +24,14 @@ knitr::include_graphics("images/welcome.jpg")
 
 
 <sub>[Photo by <a href="https://unsplash.com/@bel2000a?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Belinda Fewings</a> on <a href="https://unsplash.com/s/photos/welcome?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>]</sub>
-  
+
 ## Before we start ..
 
 Poll: How are you feeling right now?
 
 ## About Us
 
-**Carrie Wright (she/her)** 
+**Carrie Wright (she/her)**
 
 Senior Staff Scientist and Training Lead, Fred Hutchinson Cancer Center
 
@@ -39,7 +39,7 @@ Associate, Department of Biostatistics, JHSPH
 
 PhD in Biomedical Sciences
 
-Email: cwrigh60@jhu.edu  Web: https://carriewright11.github.io
+Email: cwright2@fredhutch.org Web: https://carriewright11.github.io
 
 ```{r, fig.alt="Carrie's picture", out.width = "30%", echo = FALSE, fig.align='center'}
 # knitr::include_graphics("https://ca.slack-edge.com/T023TPZA8LF-U024F9G49S8-9861ddd543db-192")
@@ -56,7 +56,7 @@ Associate, Department of Biostatistics, JHSPH
 
 PhD in Ecology
 
-Email: ava.hoffman@jhu.edu  Web: https://avahoffman.com
+Email: ahoffma2@fredhutch.org Web: https://avahoffman.com
 
 ```{r, fig.alt="Ava's picture", out.width = "30%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("modules", "Intro", "images", "ava.png"))
@@ -64,47 +64,13 @@ knitr::include_graphics(here::here("modules", "Intro", "images", "ava.png"))
 
 ## About Us
 
-**Clif McKee (he/him)**
+**Elizabeth Humphries (she/her)**
 
-Research Associate, Department of Epidemiology, JHSPH
-
-Masters and PhD in Ecology
-
-Email: cmckee7@jhu.edu Web: http://clifmckee.github.io 
-
-```{r, fig.alt="Clif's picture", out.width = "27%", echo = FALSE, fig.align='center'}
-knitr::include_graphics("https://ca.slack-edge.com/T05B63VRKQU-U05B3L06SQK-a423994b2612-512")
-```
+TODO: Elizabeth puts stuff about herself here
 
 ## About Us - TAs
 
-**Alex Newman (he/him)**
-
-3rd Year PhD Student, Department of Mental Health, BSPH   
-
-MA in Psychology, Brandeis University   
-
-BA in Biological Basis of Behavior, University of Pennsylvania  
-
-Email: anewma28@jhu.edu
-
-```{r, fig.alt="Alex's picture", out.width = "25%", echo = FALSE, fig.align='center'}
-knitr::include_graphics(here::here("modules", "Intro", "images", "Alex.jpg"))
-```
-
-## About Us - TAs
-
-**Padmashri Saravanan (she/they)**
-
-2nd Year MHS Student, Department of Epidemiology, BSPH   
-
-MSc in Mathematics, Birla Institute of Technology and Science, Pilani
-
-Email: psarava1@jhu.edu
-
-```{r, fig.alt="Padma's picture", out.width = "25%", echo = FALSE, fig.align='center'}
-knitr::include_graphics(here::here("modules", "Intro", "images", "Padma.jpg"))
-```
+TODO: Whatever TAs we have describe themseves here.
 
 ## About you!
 
@@ -176,7 +142,7 @@ knitr::include_graphics("images/Rlogo.png")
 
 * Extensive add-on software (packages)
 
-* Strong community 
+* Strong community
 
 ```{r, fig.alt="R-Ladies - a non-profit civil society community", out.width = "20%", echo = FALSE, fig.align='center'}
 knitr::include_graphics("https://github.com/rladies/branding-materials/raw/main/logo/R-LadiesGlobal_RBG_online_LogoWithText_Horizontal.png")
@@ -185,7 +151,7 @@ knitr::include_graphics("https://github.com/rladies/branding-materials/raw/main/
 
 ## Why not R?
 
-    
+
 * Little centralized support, relies on online community and package developers
 
 * Annoying to update
@@ -207,9 +173,9 @@ Why do you want to use R?
 
 ```{r, fig.alt="image of rocks with word hope painted on", out.width = "60%", echo = FALSE, fig.align='center'}
 knitr::include_graphics("images/hope.jpg")
-``` 
+```
 <sub>[Photo by <a href="https://unsplash.com/@jannerboy62?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Nick Fewings</a> on <a href="https://unsplash.com/s/photos/hope?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>]</sub>
-  
+
 
 ## Course Website
 
@@ -232,7 +198,7 @@ knitr::include_graphics("../../docs/images/Intro_to_R.png")
 - Making exploratory plots
 - Performing basic statistical tests
 - Writing R functions
-- **Building intuition** 
+- **Building intuition**
 
 ## Course Format
 
@@ -242,16 +208,15 @@ knitr::include_graphics("../../docs/images/Intro_to_R.png")
  * `r config::get("course_dates")` `r config::get("course_time")` on Zoom
  * `r config::get("holiday")`
  * Final classes will focus on final project
- 
+
 ## CoursePlus
- 
+
 `r config::get("courseplus_web")`
 
 - Upload homework
 
 ## Surveys
 
-- _End of class_ Survey from JHU: https://courseevaluations.jhsph.edu/
 - Daily survey / pulse check : `r config::get("google_survey")`
 
 ```{r, fig.alt="Surveys count", out.width = "40%", echo = FALSE, fig.align='center'}
@@ -269,7 +234,7 @@ knitr::include_graphics("images/feedback-illustration.jpeg")
 Homework and Final Project due by **`r config::get("final_due_date")`**.
 
 If you turn homework in earlier this can allow us to potentially give you feedback earlier.
- 
+
 Note: Only people taking the course for credit must turn in the assignments. However, we will evaluate all submitted assignments in case others would like feedback on their work.
 
 ## Your Setup
@@ -336,7 +301,7 @@ sum(1, 20234)
 
  **Argument** - what you pass to a function
 
-- can be data like the number 1 or 20234 
+- can be data like the number 1 or 20234
 
 ```{r}
 sum(1, 20234)
@@ -395,11 +360,11 @@ Fancier versions from the tidyverse are called **tibbles** (more on that soon!).
 ## More on Functions and Packages
 
 * When you download R, it has a "base" set of functions/packages (**base R**)  
-    * You can install additional packages for your uses from [CRAN](https://cran.r-project.org/) or [GitHub](https://github.com/) 
+    * You can install additional packages for your uses from [CRAN](https://cran.r-project.org/) or [GitHub](https://github.com/)
     * These additional packages are written by RStudio or R users/developers (like us)
     * There are also packages for bioinformatics available at [Bioconductor](https://www.bioconductor.org/)
-    
-    
+
+
 ```{r, fig.alt="Picture of R package stickers", out.width = "30%", echo = FALSE, fig.align='center'}
 knitr::include_graphics("../Intro/images/hex.png")
 ```
@@ -416,7 +381,7 @@ knitr::include_graphics("../Intro/images/hex.png")
 
 ## Tidyverse and Base R: Two Dialects
 
-We will mostly show you how to use tidyverse packages and functions. 
+We will mostly show you how to use tidyverse packages and functions.
 
 This is a newer set of packages designed for data science that can make your code more **intuitive** as compared to the original older Base R.
 
@@ -435,11 +400,11 @@ See this [article](https://tidyverse.tidyverse.org/articles/paper.html) for more
 
 ## Package Installation
 
-We will practice this in labs :) 
+We will practice this in labs :)
 
 Differs depending on the source (CRAN, GitHub, etc)
 
-Must be done **once** for each installation of R (e.g., version 4.2 >> 4.3). 
+Must be done **once** for each installation of R (e.g., version 4.2 >> 4.3).
 
 ## Installing Packages: Dropdown Menu
 
@@ -503,7 +468,7 @@ Found on our website under the `Resources` tab:
 https://daseh.org//resources.html
 
 -  videos from previous offerings of the class
--  cheatsheets for each class 
+-  cheatsheets for each class
 
 ## Help!!!
 
@@ -541,8 +506,3 @@ knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))
 ```
 
 Image by <a href="https://pixabay.com/users/geralt-9301/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=812226">Gerd Altmann</a> from <a href="https://pixabay.com//?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=812226">Pixabay</a>
-
-
-
-
-

--- a/modules/Intro/Intro.Rmd
+++ b/modules/Intro/Intro.Rmd
@@ -70,7 +70,7 @@ TODO: Elizabeth puts stuff about herself here
 
 ## About Us - TAs
 
-TODO: Whatever TAs we have describe themseves here.
+TODO: Whatever TAs we have describe themselves here.
 
 ## About you!
 

--- a/modules/Intro/Intro.Rmd
+++ b/modules/Intro/Intro.Rmd
@@ -288,7 +288,7 @@ knitr::include_graphics("images/monitors.jpg")
 
 * [Install RStudio](https://www.rstudio.com/products/rstudio/download/)
 
-More detailed instructions [on the website](https://jhudatascience.org/intro_to_r/docs/module_details/day0.html).
+More detailed instructions [on the website](https://daseh.org//docs/module_details/day0.html).
 
 RStudio is an **integrated development environment** (IDE) that makes it easier to work with R.
 
@@ -500,7 +500,7 @@ knitr::include_graphics("../../images/lol/install_packages.jpg")
 ## Useful (+ mostly Free) Resources
 
 Found on our website under the `Resources` tab:
-https://jhudatascience.org/intro_to_r/resources.html
+https://daseh.org//resources.html
 
 -  videos from previous offerings of the class
 -  cheatsheets for each class 
@@ -509,7 +509,7 @@ https://jhudatascience.org/intro_to_r/resources.html
 
 Error messages can be scary!
 
-- Check out the FAQ/Help page on the website: https://jhudatascience.org/intro_to_r/help.html
+- Check out the FAQ/Help page on the website: https://daseh.org//help.html
 - Ask questions in Slack! Copy+pasting your error messages is really helpful!
 - Leverage our awesome TA time for 1:1 troubleshooting
 
@@ -530,11 +530,11 @@ knitr::include_graphics("images/forrest-gump-running.gif")
 - Materials will be updated frequently as we improve it. Please use the **Google Form survey** so you can provide feedback throughout the class!
 - Lots of **resources** can be found on the website. _You will have access to the website after the class is over._
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
 ## Website tour!
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Intro/Intro.Rmd
+++ b/modules/Intro/Intro.Rmd
@@ -253,7 +253,7 @@ knitr::include_graphics("images/monitors.jpg")
 
 * [Install RStudio](https://www.rstudio.com/products/rstudio/download/)
 
-More detailed instructions [on the website](https://daseh.org//docs/module_details/day0.html).
+More detailed instructions [on the website](https://daseh.org/docs/module_details/day0.html).
 
 RStudio is an **integrated development environment** (IDE) that makes it easier to work with R.
 
@@ -465,7 +465,7 @@ knitr::include_graphics("../../images/lol/install_packages.jpg")
 ## Useful (+ mostly Free) Resources
 
 Found on our website under the `Resources` tab:
-https://daseh.org//resources.html
+https://daseh.org/resources.html
 
 -  videos from previous offerings of the class
 -  cheatsheets for each class
@@ -474,7 +474,7 @@ https://daseh.org//resources.html
 
 Error messages can be scary!
 
-- Check out the FAQ/Help page on the website: https://daseh.org//help.html
+- Check out the FAQ/Help page on the website: https://daseh.org/help.html
 - Ask questions in Slack! Copy+pasting your error messages is really helpful!
 - Leverage our awesome TA time for 1:1 troubleshooting
 
@@ -495,11 +495,11 @@ knitr::include_graphics("images/forrest-gump-running.gif")
 - Materials will be updated frequently as we improve it. Please use the **Google Form survey** so you can provide feedback throughout the class!
 - Lots of **resources** can be found on the website. _You will have access to the website after the class is over._
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
 ## Website tour!
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Manipulating_Data_in_R/Manipulating_Data_in_R.Rmd
+++ b/modules/Manipulating_Data_in_R/Manipulating_Data_in_R.Rmd
@@ -191,7 +191,7 @@ Newly created column names are enclosed in quotation marks.
 
 ## Data used: Charm City Circulator
 
-http://jhudatascience.org/intro_to_r/data/Charm_City_Circulator_Ridership.csv
+https://daseh.org/data/Charm_City_Circulator_Ridership.csv
 
 ```{r, message = FALSE}
 library(jhur)

--- a/modules/Manipulating_Data_in_R/Manipulating_Data_in_R.Rmd
+++ b/modules/Manipulating_Data_in_R/Manipulating_Data_in_R.Rmd
@@ -32,7 +32,7 @@ library(tidyverse)
     - `separate()` can split columns into additional columns
     - `unite()` can combine columns
 
-📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-5.pdf)
+📃[Cheatsheet](https://daseh.org/modules/cheatsheets/Day-5.pdf)
 
 ## Manipulating Data 
 
@@ -152,7 +152,7 @@ You might see old functions `gather` and `spread` when googling. These are older
 
 ```{r, message = FALSE}
 wide_vacc <- read_csv(
-  file = "https://daseh.org//data/wide_vacc.csv")
+  file = "https://daseh.org/data/wide_vacc.csv")
 ```
 
 ```{r}
@@ -331,9 +331,9 @@ wide
 
 ## Lab Part 1
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Lab](https://daseh.org//modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd)
 
 ## Joining
 
@@ -357,9 +357,9 @@ knitr::include_graphics("images/joins.png")
 
 ```{r message=FALSE}
 data_As <- read_csv(
-  file = "https://daseh.org//data/data_As_1.csv")
+  file = "https://daseh.org/data/data_As_1.csv")
 data_cold <- read_csv(
-  file = "https://daseh.org//data/data_cold_1.csv")
+  file = "https://daseh.org/data/data_cold_1.csv")
 ```
 
 ```{r}
@@ -467,9 +467,9 @@ fj
 
 ```{r message=FALSE}
 data_As <- read_csv(
-  file = "https://daseh.org//data/data_As_2.csv")
+  file = "https://daseh.org/data/data_As_2.csv")
 data_cold <- read_csv(
-  file = "https://daseh.org//data/data_cold_2.csv")
+  file = "https://daseh.org/data/data_cold_2.csv")
 ```
 
 ```{r}
@@ -566,9 +566,9 @@ anti_join(data_cold, data_As, by = "State") # order switched
 
 ## Lab Part 2
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Lab](https://daseh.org//modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Manipulating_Data_in_R/Manipulating_Data_in_R.Rmd
+++ b/modules/Manipulating_Data_in_R/Manipulating_Data_in_R.Rmd
@@ -32,7 +32,7 @@ library(tidyverse)
     - `separate()` can split columns into additional columns
     - `unite()` can combine columns
 
-📃[Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-5.pdf)
+📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-5.pdf)
 
 ## Manipulating Data 
 
@@ -152,7 +152,7 @@ You might see old functions `gather` and `spread` when googling. These are older
 
 ```{r, message = FALSE}
 wide_vacc <- read_csv(
-  file = "https://jhudatascience.org/intro_to_r/data/wide_vacc.csv")
+  file = "https://daseh.org//data/wide_vacc.csv")
 ```
 
 ```{r}
@@ -331,9 +331,9 @@ wide
 
 ## Lab Part 1
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd)
 
 ## Joining
 
@@ -357,9 +357,9 @@ knitr::include_graphics("images/joins.png")
 
 ```{r message=FALSE}
 data_As <- read_csv(
-  file = "https://jhudatascience.org/intro_to_r/data/data_As_1.csv")
+  file = "https://daseh.org//data/data_As_1.csv")
 data_cold <- read_csv(
-  file = "https://jhudatascience.org/intro_to_r/data/data_cold_1.csv")
+  file = "https://daseh.org//data/data_cold_1.csv")
 ```
 
 ```{r}
@@ -467,9 +467,9 @@ fj
 
 ```{r message=FALSE}
 data_As <- read_csv(
-  file = "https://jhudatascience.org/intro_to_r/data/data_As_2.csv")
+  file = "https://daseh.org//data/data_As_2.csv")
 data_cold <- read_csv(
-  file = "https://jhudatascience.org/intro_to_r/data/data_cold_2.csv")
+  file = "https://daseh.org//data/data_cold_2.csv")
 ```
 
 ```{r}
@@ -566,9 +566,9 @@ anti_join(data_cold, data_As, by = "State") # order switched
 
 ## Lab Part 2
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd
+++ b/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd
@@ -21,7 +21,7 @@ library(tidyr)
 
 ### 1.1
 
-Read in the SARS-CoV-2 Vaccination data from http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv. You can use the url or download the data. Assign the data the name "vacc". We will be reviewing new concepts here and incorporating some from week 1. 
+Read in the SARS-CoV-2 Vaccination data from https://daseh.org/data/USA_covid19_vaccinations.csv. You can use the url or download the data. Assign the data the name "vacc". We will be reviewing new concepts here and incorporating some from week 1. 
 
 -  Remember to use `read_csv()` from the `readr` package.
 -  Do NOT use `read.csv()`.
@@ -131,7 +131,7 @@ Modify the code from Question P.1:
 
 ### 2.1
 
-Read in the GDP and Personal Income Data from http://jhudatascience.org/intro_to_r/data/gdp_personal_income.csv. You can use the url or download the data. Call it "gdp". 
+Read in the GDP and Personal Income Data from https://daseh.org/data/gdp_personal_income.csv. You can use the url or download the data. Call it "gdp". 
 
 ```{r 2.1response}
 

--- a/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab_Key.Rmd
+++ b/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab_Key.Rmd
@@ -21,13 +21,13 @@ library(tidyr)
 
 ### 1.1
 
-Read in the SARS-CoV-2 Vaccination data from http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv. You can use the url or download the data. Assign the data the name "vacc". We will be reviewing new concepts here and incorporating some from week 1. 
+Read in the SARS-CoV-2 Vaccination data from https://daseh.org/data/USA_covid19_vaccinations.csv. You can use the url or download the data. Assign the data the name "vacc". We will be reviewing new concepts here and incorporating some from week 1. 
 
 -  Remember to use `read_csv()` from the `readr` package.
 -  Do NOT use `read.csv()`.
 
 ```{r 1.1response}
-vacc <- read_csv("http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv")
+vacc <- read_csv("https://daseh.org/data/USA_covid19_vaccinations.csv")
 # If downloaded
 # vacc <- read_csv("USA_covid19_vaccinations.csv")
 ```
@@ -121,7 +121,7 @@ Take the code from Questions 1.1 and 1.3-1.7. Chain all of this code together us
 
 ```{r P.1response}
 vacc_compare <-
-  read_csv("http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv") %>%
+  read_csv("https://daseh.org/data/USA_covid19_vaccinations.csv") %>%
   rename(Entity = `State/Territory/Federal Entity`) %>%
   select(Entity, starts_with("Percent")) %>%
   pivot_longer(cols = !Entity) %>%
@@ -140,7 +140,7 @@ Modify the code from Question P.1:
 
 ```{r P.2response}
 vacc_compare2 <-
-  read_csv("http://jhudatascience.org/intro_to_r/data/USA_covid19_vaccinations.csv") %>%
+  read_csv("https://daseh.org/data/USA_covid19_vaccinations.csv") %>%
   rename(Entity = `State/Territory/Federal Entity`) %>%
   select(Entity, starts_with("Total")) %>%
   pivot_longer(cols = !Entity) %>%
@@ -154,10 +154,10 @@ vacc_compare2
 
 ### 2.1
 
-Read in the GDP and Personal Income Data from http://jhudatascience.org/intro_to_r/data/gdp_personal_income.csv. You can use the url or download the data. Call it "gdp". 
+Read in the GDP and Personal Income Data from https://daseh.org/data/gdp_personal_income.csv. You can use the url or download the data. Call it "gdp". 
 
 ```{r 2.1response}
-gdp <- read_csv("http://jhudatascience.org/intro_to_r/data/gdp_personal_income.csv")
+gdp <- read_csv("https://daseh.org/data/gdp_personal_income.csv")
 # If downloaded
 # gdp <- read_csv("gdp_personal_income.csv")
 ```

--- a/modules/RStudio/RStudio.Rmd
+++ b/modules/RStudio/RStudio.Rmd
@@ -220,11 +220,11 @@ knitr::include_graphics("images/pane_layout.png")
 
 ## Lab: Starting with R and RMarkdown
 
-💻 [RStudio Lab](https://daseh.org//modules/RStudio/lab/RStudio_Lab.Rmd)
+💻 [RStudio Lab](https://daseh.org/modules/RStudio/lab/RStudio_Lab.Rmd)
 
 To do this lab we need to:
 
-- Download the file at the link above by clicking on it or go to the [website](https://daseh.org//materials_schedule.html) schedule page
+- Download the file at the link above by clicking on it or go to the [website](https://daseh.org/materials_schedule.html) schedule page
 - Find the downloaded file on your computer
 - Open the file in RStudio (double clicking the file name typically works)
 
@@ -284,7 +284,7 @@ knitr::include_graphics("images/output.png")
 
 ## If you get annoyed by code previews in Markdown files...
 
-See the [Help page](https://daseh.org//help.html) of the website. You can adjust this and change your RStudio settings:
+See the [Help page](https://daseh.org/help.html) of the website. You can adjust this and change your RStudio settings:
 
 Tools > Global Options > Appearance
 
@@ -441,9 +441,9 @@ knitr::include_graphics("images/double_question.png")
 -  R code goes within what is called a chunk (the gray box with a green play button)
 -  Code chunks can be modified so that they show differently in reports
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Lab](https://daseh.org//modules/RStudio/lab/RStudio_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/RStudio/lab/RStudio_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "25%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/RStudio/RStudio.Rmd
+++ b/modules/RStudio/RStudio.Rmd
@@ -220,11 +220,11 @@ knitr::include_graphics("images/pane_layout.png")
 
 ## Lab: Starting with R and RMarkdown
 
-💻 [RStudio Lab](https://jhudatascience.org/intro_to_r/modules/RStudio/lab/RStudio_Lab.Rmd)
+💻 [RStudio Lab](https://daseh.org//modules/RStudio/lab/RStudio_Lab.Rmd)
 
 To do this lab we need to:
 
-- Download the file at the link above by clicking on it or go to the [website](https://jhudatascience.org/intro_to_r/materials_schedule.html) schedule page
+- Download the file at the link above by clicking on it or go to the [website](https://daseh.org//materials_schedule.html) schedule page
 - Find the downloaded file on your computer
 - Open the file in RStudio (double clicking the file name typically works)
 
@@ -284,7 +284,7 @@ knitr::include_graphics("images/output.png")
 
 ## If you get annoyed by code previews in Markdown files...
 
-See the [Help page](https://jhudatascience.org/intro_to_r/help.html) of the website. You can adjust this and change your RStudio settings:
+See the [Help page](https://daseh.org//help.html) of the website. You can adjust this and change your RStudio settings:
 
 Tools > Global Options > Appearance
 
@@ -441,9 +441,9 @@ knitr::include_graphics("images/double_question.png")
 -  R code goes within what is called a chunk (the gray box with a green play button)
 -  Code chunks can be modified so that they show differently in reports
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/RStudio/lab/RStudio_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/RStudio/lab/RStudio_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "25%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Reproducibility/Reproducibility.Rmd
+++ b/modules/Reproducibility/Reproducibility.Rmd
@@ -161,7 +161,7 @@ Go to Help > Cheat Sheets > R Markdown Cheat Sheet (which will download it)
 
 Or checkout Help > Cheat Sheets > R Markdown Reference Guide
 
-Or checkout the 🏠 [Class Website](https://daseh.org//)!
+Or checkout the 🏠 [Class Website](https://daseh.org/)!
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics("images/markdown_cheatsheet.png")
@@ -187,8 +187,8 @@ knitr::include_graphics("images/session_info.png")
 
 ## Lab 1
 
-🏠 [Class Website](https://daseh.org//)    
-💻 [Lab](https://daseh.org//modules/Reproducibility/lab/Reproducibility_Lab.Rmd)
+🏠 [Class Website](https://daseh.org/)    
+💻 [Lab](https://daseh.org/modules/Reproducibility/lab/Reproducibility_Lab.Rmd)
 
 ## More resources
 
@@ -210,7 +210,7 @@ To help make your work more reproducible:
 - Tell your future self and others what you did!
 - Print session info!
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
 ```{r, fig.alt="The End", out.width = "25%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Reproducibility/Reproducibility.Rmd
+++ b/modules/Reproducibility/Reproducibility.Rmd
@@ -161,7 +161,7 @@ Go to Help > Cheat Sheets > R Markdown Cheat Sheet (which will download it)
 
 Or checkout Help > Cheat Sheets > R Markdown Reference Guide
 
-Or checkout the 🏠 [Class Website](https://jhudatascience.org/intro_to_r/)!
+Or checkout the 🏠 [Class Website](https://daseh.org//)!
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics("images/markdown_cheatsheet.png")
@@ -187,8 +187,8 @@ knitr::include_graphics("images/session_info.png")
 
 ## Lab 1
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)    
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Reproducibility/lab/Reproducibility_Lab.Rmd)
+🏠 [Class Website](https://daseh.org//)    
+💻 [Lab](https://daseh.org//modules/Reproducibility/lab/Reproducibility_Lab.Rmd)
 
 ## More resources
 
@@ -210,7 +210,7 @@ To help make your work more reproducible:
 - Tell your future self and others what you did!
 - Print session info!
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
 ```{r, fig.alt="The End", out.width = "25%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Statistics/Statistics.Rmd
+++ b/modules/Statistics/Statistics.Rmd
@@ -64,7 +64,7 @@ knitr::include_graphics("https://c.tenor.com/O3x8ywLm380AAAAd/chevy-chase.gif")
 
 There are plenty of resources online for learning more about these methods, as well as dedicated Biostatistics series (at different advancement levels) at the JHU School of Public Health.
 
-Check out [www.opencasestudies.org](https://www.opencasestudies.org/) for deeper dives on some of the concepts covered here and the [resource page](https://daseh.org//resources.html) for more resources.
+Check out [www.opencasestudies.org](https://www.opencasestudies.org/) for deeper dives on some of the concepts covered here and the [resource page](https://daseh.org/resources.html) for more resources.
 
 # Correlation
 
@@ -113,7 +113,7 @@ cor.test(x, y = NULL, alternative(c("two.sided", "less", "greater")),
 
 ## Correlation {.small}
 
-https://daseh.org//data/Charm_City_Circulator_Ridership.csv
+https://daseh.org/data/Charm_City_Circulator_Ridership.csv
 
 ```{r cor1, comment="", message = FALSE}
 library(jhur)
@@ -326,9 +326,9 @@ See [here](https://www.nature.com/articles/nbt1209-1135) for more about multiple
 
 ## Lab Part 1
 
-🏠 [Class Website](https://daseh.org//)  
+🏠 [Class Website](https://daseh.org/)  
 
-💻 [Lab](https://daseh.org//modules/Statistics/lab/Statistics_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Statistics/lab/Statistics_Lab.Rmd)
 
 # Regression
 
@@ -694,7 +694,7 @@ Some final notes:
 - `oddsratio()` from the `epitools` package can calculate odds ratios (outside of logistic regression - which allows more than one explanatory variable)
 - this is just the tip of the iceberg!
 
-## Resources (also on the [website](https://daseh.org//resources.html)!)
+## Resources (also on the [website](https://daseh.org/resources.html)!)
 
 For more check out:
 
@@ -706,9 +706,9 @@ Content for similar topics as this course can also be found on Leanpub.
 
 ## Lab Part 2
 
-🏠 [Class Website](https://daseh.org//)  
+🏠 [Class Website](https://daseh.org/)  
 
-💻 [Lab](https://daseh.org//modules/Statistics/lab/Statistics_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Statistics/lab/Statistics_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Statistics/Statistics.Rmd
+++ b/modules/Statistics/Statistics.Rmd
@@ -64,7 +64,7 @@ knitr::include_graphics("https://c.tenor.com/O3x8ywLm380AAAAd/chevy-chase.gif")
 
 There are plenty of resources online for learning more about these methods, as well as dedicated Biostatistics series (at different advancement levels) at the JHU School of Public Health.
 
-Check out [www.opencasestudies.org](https://www.opencasestudies.org/) for deeper dives on some of the concepts covered here and the [resource page](https://jhudatascience.org/intro_to_r/resources.html) for more resources.
+Check out [www.opencasestudies.org](https://www.opencasestudies.org/) for deeper dives on some of the concepts covered here and the [resource page](https://daseh.org//resources.html) for more resources.
 
 # Correlation
 
@@ -113,7 +113,7 @@ cor.test(x, y = NULL, alternative(c("two.sided", "less", "greater")),
 
 ## Correlation {.small}
 
-https://jhudatascience.org/intro_to_r/data/Charm_City_Circulator_Ridership.csv
+https://daseh.org//data/Charm_City_Circulator_Ridership.csv
 
 ```{r cor1, comment="", message = FALSE}
 library(jhur)
@@ -326,9 +326,9 @@ See [here](https://www.nature.com/articles/nbt1209-1135) for more about multiple
 
 ## Lab Part 1
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)  
+🏠 [Class Website](https://daseh.org//)  
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Statistics/lab/Statistics_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Statistics/lab/Statistics_Lab.Rmd)
 
 # Regression
 
@@ -694,7 +694,7 @@ Some final notes:
 - `oddsratio()` from the `epitools` package can calculate odds ratios (outside of logistic regression - which allows more than one explanatory variable)
 - this is just the tip of the iceberg!
 
-## Resources (also on the [website](https://jhudatascience.org/intro_to_r/resources.html)!)
+## Resources (also on the [website](https://daseh.org//resources.html)!)
 
 For more check out:
 
@@ -710,9 +710,9 @@ Content for similar topics as this course can also be found on Leanpub.
 
 ## Lab Part 2
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)  
+🏠 [Class Website](https://daseh.org//)  
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Statistics/lab/Statistics_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Statistics/lab/Statistics_Lab.Rmd)
 
 ```{r, fig.alt="The End", out.width = "50%", echo = FALSE, fig.align='center'}
 knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))

--- a/modules/Statistics/Statistics.Rmd
+++ b/modules/Statistics/Statistics.Rmd
@@ -42,7 +42,7 @@ library(emo)
 
 ## Overview
 
-We will cover how to use R to compute some of basic statistics and fit some basic statistical models. 
+We will cover how to use R to compute some of basic statistics and fit some basic statistical models.
 
 * Correlation
 * T-test
@@ -50,7 +50,7 @@ We will cover how to use R to compute some of basic statistics and fit some basi
 
 <br>
 
-## 
+##
 
 ```{r, fig.alt="I was told there would be no math", out.width = "35%", echo = FALSE, fig.show='hold',fig.align='center'}
 knitr::include_graphics("https://c.tenor.com/O3x8ywLm380AAAAd/chevy-chase.gif")
@@ -82,7 +82,7 @@ knitr::include_graphics("https://www.mathsisfun.com/data/images/correlation-exam
 
 See this [case study](https://www.opencasestudies.org/ocs-bp-co2-emissions/#Data_Analysis) for more information.
 
-## Correlation 
+## Correlation
 
 Function `cor()` computes correlation in R.
 
@@ -125,7 +125,7 @@ head(circ)
 
 First, we compute correlation by providing two vectors.
 
-Like other functions, if there are `NA`s, you get `NA` as the result.  But if you specify use only the complete observations, then it will give you correlation using the non-missing data. 
+Like other functions, if there are `NA`s, you get `NA` as the result.  But if you specify use only the complete observations, then it will give you correlation using the non-missing data.
 
 ```{r}
 # x and y must be numeric vectors
@@ -191,7 +191,7 @@ circ %>%
 
 We can compute correlation for all pairs of columns of a data frame / matrix. This is often called, *"computing a correlation matrix"*.
 
-Columns must be all numeric! 
+Columns must be all numeric!
 
 ```{r}
 circ_subset_Average <- circ %>% select(ends_with("Average"))
@@ -229,12 +229,12 @@ knitr::include_graphics(here::here("images/lyme_and_fried_chicken.png"))
 
 ## T-test
 
-The commonly used are: 
+The commonly used are:
 
-- **one-sample t-test** -- used to test mean of a variable in one group 
+- **one-sample t-test** -- used to test mean of a variable in one group
 - **two-sample t-test** -- used to test difference in means of a variable between two groups (if the "two groups" are data of the *same* individuals collected at 2 time points, we say it is two-sample paired t-test)
 
-The `t.test()` function in R is one to address the above. 
+The `t.test()` function in R is one to address the above.
 
 ```
 t.test(x, y = NULL,
@@ -245,7 +245,7 @@ t.test(x, y = NULL,
 
 ## Running one-sample t-test {.smaller}
 
-It tests the mean of a variable in one group. By default (i.e., without us explicitly specifying values of other arguments): 
+It tests the mean of a variable in one group. By default (i.e., without us explicitly specifying values of other arguments):
 
 - tests whether a mean of a variable is equal to 0 (`mu = 0`)
 - uses "two sided" alternative (`alternative = "two.sided"`)
@@ -262,8 +262,8 @@ t.test(x)
 
 It tests the difference in means of a variable between two groups. By default:
 
-- tests whether difference in means of a variable is equal to 0 (`mu = 0`) 
-- uses "two sided" alternative (`alternative = "two.sided"`) 
+- tests whether difference in means of a variable is equal to 0 (`mu = 0`)
+- uses "two sided" alternative (`alternative = "two.sided"`)
 - returns result assuming confidence level 0.95 (`conf.level = 0.95`)
 - assumes data are not paired (`paired = FALSE`)
 - assumes true variance in the two groups is not equal (`var.equal = FALSE`)
@@ -281,7 +281,7 @@ sum(is.na(y)) # count NAs in x and y
 t.test(x, y)
 ```
 
-## T-test: retrieving information from the result with `broom` package 
+## T-test: retrieving information from the result with `broom` package
 
 The `broom` package has a `tidy()` function that can organize results into a data frame so that they are easily manipulated (or nicely printed)
 
@@ -334,7 +334,7 @@ See [here](https://www.nature.com/articles/nbt1209-1135) for more about multiple
 
 ## Linear regression
 
-Linear regression is a method to model the relationship between a response and one or more explanatory variables. 
+Linear regression is a method to model the relationship between a response and one or more explanatory variables.
 
 Most commonly used statistical tests are actually specialized regressions, including the two sample t-test, [see here for more](https://www.opencasestudies.org/ocs-bp-diet/#(t)-test_and_linear_regression).
 
@@ -343,7 +343,7 @@ Most commonly used statistical tests are actually specialized regressions, inclu
 Here is some of the notation, so it is easier to understand the commands/results.
 
 $$
-y_i = \alpha + \beta x_{i} + \varepsilon_i 
+y_i = \alpha + \beta x_{i} + \varepsilon_i
 $$
 where:
 
@@ -378,12 +378,12 @@ print(ggplot(data = iris, aes(x = Petal.Length, y = Petal.Width)) +
 
 ## Linear regression {.smaller}
 
-Linear regression is a method to model the relationship between a response and one or more explanatory variables. 
+Linear regression is a method to model the relationship between a response and one or more explanatory variables.
 
 We provide a little notation here so some of the commands are easier to put in the proper context.
 
 $$
-y_i = \alpha + \beta_1 x_{i1} + \beta_2 x_{i2} + \beta_3 x_{i3} + \varepsilon_i 
+y_i = \alpha + \beta_1 x_{i1} + \beta_2 x_{i2} + \beta_3 x_{i3} + \varepsilon_i
 $$
 where:
 
@@ -395,72 +395,72 @@ where:
 
 See this [case study](https://www.opencasestudies.org/ocs-bp-diet/#Data_Analysis) for more details.
 
-## Linear regression fit in R 
+## Linear regression fit in R
 
-To fit regression models in R, we use the function `glm()` (Generalized Linear Model). 
+To fit regression models in R, we use the function `glm()` (Generalized Linear Model).
 
 You may also see `lm()` which is a more limited function that only allows for normally/Gaussian distributed error terms (aka typical linear regressions).
 
 We typically provide two arguments:
 
-- `formula` -- model formula written using names of columns in our data 
-- `data` -- our data frame 
+- `formula` -- model formula written using names of columns in our data
+- `data` -- our data frame
 
-## Linear regression fit in R: model formula 
+## Linear regression fit in R: model formula
 
-Model formula 
+Model formula
 $$
-y_i = \alpha + \beta x_{i} + \varepsilon_i 
+y_i = \alpha + \beta x_{i} + \varepsilon_i
 $$
-In R translates to 
+In R translates to
 
 <p style="text-align: center;">
 `y ~ x`
 </p>
 
-## Linear regression fit in R: model formula 
+## Linear regression fit in R: model formula
 
-Model formula 
+Model formula
 $$
-y_i = \alpha + \beta x_{i} + \varepsilon_i 
+y_i = \alpha + \beta x_{i} + \varepsilon_i
 $$
-In R translates to 
+In R translates to
 
 <p style="text-align: center;">
 `y ~ x`
 </p>
 
-In practice, `y` and `x` are replaced with the **names of columns from our data set**. 
+In practice, `y` and `x` are replaced with the **names of columns from our data set**.
 
-For example, if we want to fit a regression model where outcome is `income` and predictor is `years_of_education`, our formula would be: 
+For example, if we want to fit a regression model where outcome is `income` and predictor is `years_of_education`, our formula would be:
 
 <p style="text-align: center;">
 `income ~ years_of_education`
 </p>
 
-## Linear regression fit in R: model formula 
+## Linear regression fit in R: model formula
 
-Model formula 
+Model formula
 $$
-y_i = \alpha + \beta_1 x_{i1} + \beta_2 x_{i2} + \beta_3 x_{i3} + \varepsilon_i 
+y_i = \alpha + \beta_1 x_{i1} + \beta_2 x_{i2} + \beta_3 x_{i3} + \varepsilon_i
 $$
-In R translates to 
+In R translates to
 
 <p style="text-align: center;">
 `y ~ x1 + x2 + x3`
 </p>
 
-In practice, `y` and `x1`, `x2`, `x3` are replaced with the **names of columns from our data set**. 
+In practice, `y` and `x1`, `x2`, `x3` are replaced with the **names of columns from our data set**.
 
-For example, if we want to fit a regression model where outcome is `income` and predictors are `years_of_education`, `age`, and `location` then our formula would be: 
+For example, if we want to fit a regression model where outcome is `income` and predictors are `years_of_education`, `age`, and `location` then our formula would be:
 
 <p style="text-align: center;">
 `income ~ years_of_education + age + location`
 </p>
 
-## Linear regression 
+## Linear regression
 
-We will use data about emergency room doctor complaints. 
+We will use data about emergency room doctor complaints.
 
 "Data was recorded on 44 doctors working in an emergency service at a hospital to study the factors affecting the number of complaints received."
 
@@ -472,7 +472,7 @@ data(esdcomp)
 esdcomp
 ```
 
-## Linear regression: model fitting 
+## Linear regression: model fitting
 
 We fit linear regression model with the number of patient visits (`visits`) as an outcome and total number of hours worked (`hours`) as a predictor. In other words, we are evaluation if the number of hours worked is predictive of the number of visits a doctor had.
 
@@ -517,7 +517,7 @@ fit2 %>%
   glimpse()
 ```
 
-## Linear regression: factors 
+## Linear regression: factors
 
 Factors get special treatment in regression models - lowest level of the factor is the comparison group, and all other factors are **relative** to its values.
 
@@ -594,9 +594,9 @@ ggplot(esdcomp, aes(x = hours, y = visits, color = residency)) +
 
 ## Generalized linear models (GLMs)
 
-Generalized linear models (GLMs) allow for fitting regressions for non-continuous/normal outcomes. Examples include: logistic regression, Poisson regression. 
+Generalized linear models (GLMs) allow for fitting regressions for non-continuous/normal outcomes. Examples include: logistic regression, Poisson regression.
 
-Add the `family` argument -- a description of the error distribution and link function to be used in the model. These include: 
+Add the `family` argument -- a description of the error distribution and link function to be used in the model. These include:
 
 - `binomial(link = "logit")` - outcome is binary
 - `poisson(link = "log")` - outcome is count or rate
@@ -606,11 +606,11 @@ Very important to use the right test!
 
 See this [case study](https://www.opencasestudies.org/ocs-bp-vaping-case-study/#Data_Analysis) for more information.
 
-See `?family` documentation for details of family functions. 
+See `?family` documentation for details of family functions.
 
 ## Logistic regression {.smaller}
 
-We will use data about breast cancer tumors. 
+We will use data about breast cancer tumors.
 
 "The purpose of this study was to determine whether a new procedure called fine needle aspiration which draws only a small sample of tissue could be effective in determining tumor status."
 
@@ -637,7 +637,7 @@ summary(binom_fit)
 
 > An odds ratio (OR) is a measure of association between an exposure and an outcome. The OR represents the odds that an outcome will occur given a particular exposure, compared to the odds of the outcome occurring in the absence of that exposure.
 
-Check out [this paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2938757/). 
+Check out [this paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2938757/).
 
 ## Odds ratios
 
@@ -676,11 +676,11 @@ oddsratio(predictor, response)
 
 See this [case study](https://www.opencasestudies.org/ocs-bp-vaping-case-study/#Logistic_regression_%E2%80%9Cby_hand%E2%80%9D_and_by_model) for more information.
 
-## Final note 
+## Final note
 
-Some final notes: 
+Some final notes:
 
-- Researcher's responsibility to **understand the statistical method**  they use -- underlying assumptions, correct interpretation of method results 
+- Researcher's responsibility to **understand the statistical method**  they use -- underlying assumptions, correct interpretation of method results
 
 - Researcher's responsibility to **understand the R software**  they use -- meaning of function's arguments and meaning of  function's output elements
 
@@ -702,10 +702,6 @@ For more check out:
 - [this chart on when to do what test](https://www.scribbr.com/statistics/statistical-tests/)
 - [opencasestudies.org](www.opencasestudies.org)
 
-For classes at JHU School of Public Health:
-
-- [PH.140.621, PH.140.622, PH.140.623, PH.140.62 - Statistical Methods in Public Health I, II, III, and IV](https://e-catalogue.jhu.edu/course-descriptions/biostatistics/) - The class is mostly taught in STATA, but you can also join a group of students working in R. The class covers many topics in statistical analysis for public health data.
-- [PH.140.778 - Statistical Computing, Algorithm, and Software Development](https://www.jhsph.edu/courses/course/36737/2022/140.778.01/statistical-computing-algorithm-and-software-devel) - A more advanced course for working with data in R.
 Content for similar topics as this course can also be found on Leanpub.
 
 ## Lab Part 2
@@ -719,7 +715,3 @@ knitr::include_graphics(here::here("images/the-end-g23b994289_1280.jpg"))
 ```
 
 Image by <a href="https://pixabay.com/users/geralt-9301/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=812226">Gerd Altmann</a> from <a href="https://pixabay.com//?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=812226">Pixabay</a>
-
-
-
-

--- a/modules/Statistics/lab/Statistics_Lab.Rmd
+++ b/modules/Statistics/lab/Statistics_Lab.Rmd
@@ -67,7 +67,7 @@ Perform a t-test to determine if there is evidence of a difference between child
 
 ### 2.1
 
-Read in the Kaggle cars auction dataset using `read_kaggle()` from the `jhur` package.  Assign it to the "cars" variable. You can also find the data here:  http://jhudatascience.org/intro_to_r/data/kaggleCarAuction.csv.
+Read in the Kaggle cars auction dataset using `read_kaggle()` from the `jhur` package.  Assign it to the "cars" variable. You can also find the data here:  https://daseh.org/data/kaggleCarAuction.csv.
 
 ```{r 2.1response}
 

--- a/modules/Statistics/lab/Statistics_Lab.Rmd
+++ b/modules/Statistics/lab/Statistics_Lab.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ### 1.1
 
-Load the libraries needed in this lab. Then, read in the following child mortality data using `read_mortality()` function from `jhur` package. Assign it to the "mort" variable. Change its first column name from `...1` into `country`. You can also find the data here: https://daseh.org//data/mortality.csv
+Load the libraries needed in this lab. Then, read in the following child mortality data using `read_mortality()` function from `jhur` package. Assign it to the "mort" variable. Change its first column name from `...1` into `country`. You can also find the data here: https://daseh.org/data/mortality.csv
 
 Note that the data has lots of `NA` values - don't worry if you see that.
 

--- a/modules/Statistics/lab/Statistics_Lab.Rmd
+++ b/modules/Statistics/lab/Statistics_Lab.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ### 1.1
 
-Load the libraries needed in this lab. Then, read in the following child mortality data using `read_mortality()` function from `jhur` package. Assign it to the "mort" variable. Change its first column name from `...1` into `country`. You can also find the data here: https://jhudatascience.org/intro_to_r/data/mortality.csv
+Load the libraries needed in this lab. Then, read in the following child mortality data using `read_mortality()` function from `jhur` package. Assign it to the "mort" variable. Change its first column name from `...1` into `country`. You can also find the data here: https://daseh.org//data/mortality.csv
 
 Note that the data has lots of `NA` values - don't worry if you see that.
 

--- a/modules/Statistics/lab/Statistics_Lab_Key.Rmd
+++ b/modules/Statistics/lab/Statistics_Lab_Key.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ### 1.1
 
-Load the libraries needed in this lab. Then, read in the following child mortality data using `read_mortality()` function from `jhur` package. Assign it to the "mort" variable. Change its first column name from `...1` into `country`. You can also find the data here: https://daseh.org//data/mortality.csv
+Load the libraries needed in this lab. Then, read in the following child mortality data using `read_mortality()` function from `jhur` package. Assign it to the "mort" variable. Change its first column name from `...1` into `country`. You can also find the data here: https://daseh.org/data/mortality.csv
 
 Note that the data has lots of `NA` values - don't worry if you see that.
 

--- a/modules/Statistics/lab/Statistics_Lab_Key.Rmd
+++ b/modules/Statistics/lab/Statistics_Lab_Key.Rmd
@@ -86,7 +86,7 @@ tidy(t.test(x, y))
 
 ### 2.1
 
-Read in the Kaggle cars auction dataset using `read_kaggle()` from the `jhur` package.  Assign it to the "cars" variable. You can also find the data here:  http://jhudatascience.org/intro_to_r/data/kaggleCarAuction.csv.
+Read in the Kaggle cars auction dataset using `read_kaggle()` from the `jhur` package.  Assign it to the "cars" variable. You can also find the data here:  https://daseh.org/data/kaggleCarAuction.csv.
 
 ```{r 2.1response}
 cars <- read_kaggle()

--- a/modules/Statistics/lab/Statistics_Lab_Key.Rmd
+++ b/modules/Statistics/lab/Statistics_Lab_Key.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ### 1.1
 
-Load the libraries needed in this lab. Then, read in the following child mortality data using `read_mortality()` function from `jhur` package. Assign it to the "mort" variable. Change its first column name from `...1` into `country`. You can also find the data here: https://jhudatascience.org/intro_to_r/data/mortality.csv
+Load the libraries needed in this lab. Then, read in the following child mortality data using `read_mortality()` function from `jhur` package. Assign it to the "mort" variable. Change its first column name from `...1` into `country`. You can also find the data here: https://daseh.org//data/mortality.csv
 
 Note that the data has lots of `NA` values - don't worry if you see that.
 

--- a/modules/Subsetting_Data_in_R/Subsetting_Data_in_R.Rmd
+++ b/modules/Subsetting_Data_in_R/Subsetting_Data_in_R.Rmd
@@ -31,7 +31,7 @@ We are constantly making improvements.
 -  Reproducible science makes everyone's life easier!  
 - `readr`has helpful functions like `read_csv()` that can help you import data into R  
 
-📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-2.pdf)
+📃[Cheatsheet](https://daseh.org/modules/cheatsheets/Day-2.pdf)
 
 
 ## Overview
@@ -293,7 +293,7 @@ head(renamed_annualDosage)
 
 When you can, avoid spaces, special punctuation, or numbers in column names, as these require special treatment to refer to them. 
 
-See https://daseh.org//resources/quotes_vs_backticks.html for more guidance.
+See https://daseh.org/resources/quotes_vs_backticks.html for more guidance.
 
 ```{r, eval = FALSE}
  # this will cause an error
@@ -424,14 +424,14 @@ clean_names(test)
 - if your original data has rownames, you need to use `rownames_to_column` before converting to tibble
 - the `rename()` function of `dplyr` can help you rename columns
 - avoid using punctuation (except underscores), spaces, and numbers (to start or alone) in column names
-- if you must do a nonstandard column name - typically use backticks around it. See https://daseh.org//resources/quotes_vs_backticks.html.
+- if you must do a nonstandard column name - typically use backticks around it. See https://daseh.org/resources/quotes_vs_backticks.html.
 - avoid copy and pasting code from other sources - quotation marks will change!
 - check out `janitor` if you need to make lots of column name changes
 
 ## Lab Part 1
 
-🏠 [Class Website](https://daseh.org//)    
-💻 [Lab](https://daseh.org//modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
+🏠 [Class Website](https://daseh.org/)    
+💻 [Lab](https://daseh.org/modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
 
 # Subsetting Columns
 
@@ -696,8 +696,8 @@ https://media.giphy.com/media/5b5OU7aUekfdSAER5I/giphy.gif
 
 ## Lab Part 2
 
-🏠 [Class Website](https://daseh.org//)    
-💻 [Lab](https://daseh.org//modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
+🏠 [Class Website](https://daseh.org/)    
+💻 [Lab](https://daseh.org/modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
 
 ## Get the data
 
@@ -977,9 +977,9 @@ Even though `$` is easier for creating new columns, `mutate` is really powerful,
 
 ## Lab Part 3
 
-🏠 [Class Website](https://daseh.org//)
+🏠 [Class Website](https://daseh.org/)
 
-💻 [Lab](https://daseh.org//modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
+💻 [Lab](https://daseh.org/modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
 
 
 

--- a/modules/Subsetting_Data_in_R/Subsetting_Data_in_R.Rmd
+++ b/modules/Subsetting_Data_in_R/Subsetting_Data_in_R.Rmd
@@ -31,7 +31,7 @@ We are constantly making improvements.
 -  Reproducible science makes everyone's life easier!  
 - `readr`has helpful functions like `read_csv()` that can help you import data into R  
 
-📃[Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-2.pdf)
+📃[Cheatsheet](https://daseh.org//modules/cheatsheets/Day-2.pdf)
 
 
 ## Overview
@@ -293,7 +293,7 @@ head(renamed_annualDosage)
 
 When you can, avoid spaces, special punctuation, or numbers in column names, as these require special treatment to refer to them. 
 
-See https://jhudatascience.org/intro_to_r/resources/quotes_vs_backticks.html for more guidance.
+See https://daseh.org//resources/quotes_vs_backticks.html for more guidance.
 
 ```{r, eval = FALSE}
  # this will cause an error
@@ -424,14 +424,14 @@ clean_names(test)
 - if your original data has rownames, you need to use `rownames_to_column` before converting to tibble
 - the `rename()` function of `dplyr` can help you rename columns
 - avoid using punctuation (except underscores), spaces, and numbers (to start or alone) in column names
-- if you must do a nonstandard column name - typically use backticks around it. See https://jhudatascience.org/intro_to_r/resources/quotes_vs_backticks.html.
+- if you must do a nonstandard column name - typically use backticks around it. See https://daseh.org//resources/quotes_vs_backticks.html.
 - avoid copy and pasting code from other sources - quotation marks will change!
 - check out `janitor` if you need to make lots of column name changes
 
 ## Lab Part 1
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)    
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
+🏠 [Class Website](https://daseh.org//)    
+💻 [Lab](https://daseh.org//modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
 
 # Subsetting Columns
 
@@ -696,8 +696,8 @@ https://media.giphy.com/media/5b5OU7aUekfdSAER5I/giphy.gif
 
 ## Lab Part 2
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)    
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
+🏠 [Class Website](https://daseh.org//)    
+💻 [Lab](https://daseh.org//modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
 
 ## Get the data
 
@@ -977,9 +977,9 @@ Even though `$` is easier for creating new columns, `mutate` is really powerful,
 
 ## Lab Part 3
 
-🏠 [Class Website](https://jhudatascience.org/intro_to_r/)
+🏠 [Class Website](https://daseh.org//)
 
-💻 [Lab](https://jhudatascience.org/intro_to_r/modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
+💻 [Lab](https://daseh.org//modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab.Rmd)
 
 
 

--- a/resources.Rmd
+++ b/resources.Rmd
@@ -29,15 +29,15 @@ Here are additional resources to help you on your R journey - either before, dur
 
 <details><summary> <span style = "color: #5383bb;"> **Class Cheatsheets**</span></summary><br>
 
-- [Day 1 - RStudio & Reproducibility Cheatsheet](https://daseh.org//modules/cheatsheets/Day-1.pdf)
-- [Day 2 - Basic R & Data Input/Output Cheatsheet](https://daseh.org//modules/cheatsheets/Day-2.pdf)
-- [Day 3 - Data Subsetting  Cheatsheet](https://daseh.org//modules/cheatsheets/Day-3.pdf)
-- [Day 4 - Data Summarization & Data Classes Cheatsheet](https://daseh.org//modules/cheatsheets/Day-4.pdf)
-- [Day 5 - Data Cleaning Cheatsheet](https://daseh.org//modules/cheatsheets/Day-5.pdf)
-- [Day 6 - Data Manipulation & Data Visualization `esquisse` Cheatsheet](https://daseh.org//modules/cheatsheets/Day-6.pdf)
-- [Day 7 - Data Visualization `ggplot2` & Factors Cheatsheet](https://daseh.org//modules/cheatsheets/Day-7.pdf)
-- [Day 8 - Statistics Cheatsheet](https://daseh.org//modules/cheatsheets/Day-8.pdf)
-- [Day 9 - Functions Cheatsheet](https://daseh.org//modules/cheatsheets/Day-9.pdf)
+- [Day 1 - RStudio & Reproducibility Cheatsheet](https://daseh.org/modules/cheatsheets/Day-1.pdf)
+- [Day 2 - Basic R & Data Input/Output Cheatsheet](https://daseh.org/modules/cheatsheets/Day-2.pdf)
+- [Day 3 - Data Subsetting  Cheatsheet](https://daseh.org/modules/cheatsheets/Day-3.pdf)
+- [Day 4 - Data Summarization & Data Classes Cheatsheet](https://daseh.org/modules/cheatsheets/Day-4.pdf)
+- [Day 5 - Data Cleaning Cheatsheet](https://daseh.org/modules/cheatsheets/Day-5.pdf)
+- [Day 6 - Data Manipulation & Data Visualization `esquisse` Cheatsheet](https://daseh.org/modules/cheatsheets/Day-6.pdf)
+- [Day 7 - Data Visualization `ggplot2` & Factors Cheatsheet](https://daseh.org/modules/cheatsheets/Day-7.pdf)
+- [Day 8 - Statistics Cheatsheet](https://daseh.org/modules/cheatsheets/Day-8.pdf)
+- [Day 9 - Functions Cheatsheet](https://daseh.org/modules/cheatsheets/Day-9.pdf)
 - [Additional RStudio "Cheatsheets"](https://www.rstudio.com/resources/cheatsheets/)
 
 </details>
@@ -46,8 +46,8 @@ Here are additional resources to help you on your R journey - either before, dur
 
 <details><summary> <span style = "color: #5383bb;"> **Troubleshooting Guides**</span></summary><br>
 
-- [Guide on when to use quotes or backticks](https://daseh.org//resources/quotes_vs_backticks.html)
-- [Guide on what functions require pulling values out first](https://daseh.org//resources/functions_for_vectors.html)
+- [Guide on when to use quotes or backticks](https://daseh.org/resources/quotes_vs_backticks.html)
+- [Guide on what functions require pulling values out first](https://daseh.org/resources/functions_for_vectors.html)
 
 </details>
 

--- a/resources.Rmd
+++ b/resources.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Resources"
-output: 
+output:
   html_document
 ---
 
@@ -15,13 +15,13 @@ Here are additional resources to help you on your R journey - either before, dur
 
 <details open><summary> <span style = "color: #5383bb;"> **Help Getting Started**</span></summary><br>
 
-- [R reference card](http://cran.r-project.org/doc/contrib/Short-refcard.pdf) 
-- [R introductory guide](https://cran.r-project.org/doc/manuals/r-release/R-intro.html) 
-- [R jargon](https://link.springer.com/content/pdf/bbm%3A978-1-4419-1318-0%2F1.pdf) 
+- [R reference card](http://cran.r-project.org/doc/contrib/Short-refcard.pdf)
+- [R introductory guide](https://cran.r-project.org/doc/manuals/r-release/R-intro.html)
+- [R jargon](https://link.springer.com/content/pdf/bbm%3A978-1-4419-1318-0%2F1.pdf)
 - [R terminology](https://cran.r-project.org/doc/manuals/r-release/R-lang.pdf)
 - [What is the Tidyverse/what packages are in it?](https://www.tidyverse.org/packages/)
 - [Where do package names come from?](https://www.statworx.com/en/content-hub/blog/why-is-it-called-that-way-origin-and-meaning-of-r-package-names/)
-- [Lawlor et al. 2022](https://doi.org/10.1371/journal.pcbi.1010372): Ten simple rules for teaching yourself R 
+- [Lawlor et al. 2022](https://doi.org/10.1371/journal.pcbi.1010372): Ten simple rules for teaching yourself R
 
 </details>
 
@@ -63,10 +63,10 @@ Here are additional resources to help you on your R journey - either before, dur
 
 <details open><summary> <span style = "color: #5383bb;"> **Extra help**</span></summary><br>
 
-**Need help with data import?** 
+**Need help with data import?**
 
 - [Video on data import](https://youtu.be/LEkNfJgpunQ)
-- [Video](https://www.youtube.com/watch?v=we6vwB7DsNU) for PC users who want to see how to move files around (especially from downloads) 
+- [Video](https://www.youtube.com/watch?v=we6vwB7DsNU) for PC users who want to see how to move files around (especially from downloads)
 - [Video](https://www.youtube.com/watch?v=Ao9e0cDzMrE) for Mac users who want to see how to move files around (especially from downloads)
 - [Extra information about file paths](https://docs.google.com/presentation/d/18u1Vhd3Uq-QprC0btpxS_-Ka-LKVUvncyoqdbGdb-g4/edit?usp=sharing)
 
@@ -114,15 +114,9 @@ Here are additional resources to help you on your R journey - either before, dur
 - [Introduction to Reproducibility](https://jhudatascience.org/Reproducibility_in_Cancer_Informatics/)
 - [Advanced Reproducibility](https://jhudatascience.org/Adv_Reproducibility_in_Cancer_Informatics/)
 
-#### **Classes at JHU**
-
-- [PH.140.621, PH.140.622, PH.140.623, PH.140.62 - Statistical Methods in Public Health I, II, III, and IV](https://e-catalogue.jhu.edu/course-descriptions/biostatistics/) - The class is mostly taught in STATA, but you can also join a group of students working in R. The class covers many topics in statistical analysis for public health data.
-- [PH.140.778 - Statistical Computing, Algorithm, and Software Development](https://www.jhsph.edu/courses/course/36737/2022/140.778.01/statistical-computing-algorithm-and-software-devel) - A more advanced course for working with data in R.
-    - Content for similar topics as this course can also be found on [Leanpub](https://leanpub.com/advstatcomp).
-
 #### **R Conferences**
 
-- The [RStudio/Posit conference](https://posit.co/conference/) has lots of useful workshops! 
+- The [RStudio/Posit conference](https://posit.co/conference/) has lots of useful workshops!
 - useR! — International R User Conference information can be found [here](https://www.r-project.org/conferences/).
 
 </details>
@@ -132,7 +126,7 @@ Here are additional resources to help you on your R journey - either before, dur
 <details><summary> <span style = "color: #5383bb;"> **R for Stata, SPSS, and SAS files**</span></summary><br>
 
 - The [Haven](https://haven.tidyverse.org/) package  
- (This package is super useful for reading and writing files so that they are compatible across Stata, SPSS, SAS, and R) 
+ (This package is super useful for reading and writing files so that they are compatible across Stata, SPSS, SAS, and R)
 - [R vs Stata](https://link.springer.com/content/pdf/bbm%3A978-1-4419-1318-0%2F1.pdf)  
 (See page 505)
 - [R <-> SAS Cheatsheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/sas-r.pdf)
@@ -154,7 +148,7 @@ Here are additional resources to help you on your R journey - either before, dur
 <details><summary> <span style = "color: #5383bb;"> **Videos of Previous Online Lectures**</span></summary><br>
 
   **From Summer Institute 2023**
-  
+
   ```{r, echo = FALSE, message = FALSE, results='asis'}
   mat <- matrix(c(
     "Introduction", "https://youtu.be/aIJrFKQYnP8",
@@ -181,7 +175,7 @@ Here are additional resources to help you on your R journey - either before, dur
   ```
 
   **From Summer Institute 2022**
-  
+
   ```{r, echo = FALSE, message = FALSE, results='asis'}
   mat <- matrix(c(
     "RStudio and Reproducibility", "https://www.youtube.com/watch?v=eCsD0f0q6rY&t=9s",
@@ -203,9 +197,9 @@ Here are additional resources to help you on your R journey - either before, dur
   knitr::kable(mat, format = "html") %>%
     kable_styling()
   ```
-  
+
   **From Winter Institute 2022**
-  
+
   ```{r, echo = FALSE, message = FALSE, results='asis'}
   mat <- matrix(c(
     "RStudio", "https://youtu.be/zpAQrglIJb0",
@@ -228,9 +222,9 @@ Here are additional resources to help you on your R journey - either before, dur
   knitr::kable(mat, format = "html") %>%
     kable_styling()
   ```
-  
+
   **From Summer Institute 2021**
-  
+
   ```{r, echo = FALSE, message = FALSE, results='asis'}
   mat <- matrix(c(
     "RStudio", "https://youtu.be/zpAQrglIJb0",
@@ -251,9 +245,9 @@ Here are additional resources to help you on your R journey - either before, dur
   knitr::kable(mat, format = "html") %>%
     kable_styling()
   ```
-  
+
   **From Winter Institute 2020**
-  
+
   ```{r, echo = FALSE, message = FALSE, results='asis'}
   mat <- matrix(c(
     "RStudio and Data Classes", "https://youtu.be/vyIsDnsq5jY",
@@ -270,9 +264,9 @@ Here are additional resources to help you on your R journey - either before, dur
   knitr::kable(mat, format = "html") %>%
     kable_styling()
   ```
-  
+
   **From Summer Institute 2017**
-  
+
   ```{r videos, echo = FALSE, message = FALSE, results='asis'}
   mat <- matrix(c(
     "Day 1", "https://youtu.be/Xi-wsACc7p0",

--- a/resources.Rmd
+++ b/resources.Rmd
@@ -29,15 +29,15 @@ Here are additional resources to help you on your R journey - either before, dur
 
 <details><summary> <span style = "color: #5383bb;"> **Class Cheatsheets**</span></summary><br>
 
-- [Day 1 - RStudio & Reproducibility Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-1.pdf)
-- [Day 2 - Basic R & Data Input/Output Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-2.pdf)
-- [Day 3 - Data Subsetting  Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-3.pdf)
-- [Day 4 - Data Summarization & Data Classes Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-4.pdf)
-- [Day 5 - Data Cleaning Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-5.pdf)
-- [Day 6 - Data Manipulation & Data Visualization `esquisse` Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-6.pdf)
-- [Day 7 - Data Visualization `ggplot2` & Factors Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-7.pdf)
-- [Day 8 - Statistics Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-8.pdf)
-- [Day 9 - Functions Cheatsheet](https://jhudatascience.org/intro_to_r/modules/cheatsheets/Day-9.pdf)
+- [Day 1 - RStudio & Reproducibility Cheatsheet](https://daseh.org//modules/cheatsheets/Day-1.pdf)
+- [Day 2 - Basic R & Data Input/Output Cheatsheet](https://daseh.org//modules/cheatsheets/Day-2.pdf)
+- [Day 3 - Data Subsetting  Cheatsheet](https://daseh.org//modules/cheatsheets/Day-3.pdf)
+- [Day 4 - Data Summarization & Data Classes Cheatsheet](https://daseh.org//modules/cheatsheets/Day-4.pdf)
+- [Day 5 - Data Cleaning Cheatsheet](https://daseh.org//modules/cheatsheets/Day-5.pdf)
+- [Day 6 - Data Manipulation & Data Visualization `esquisse` Cheatsheet](https://daseh.org//modules/cheatsheets/Day-6.pdf)
+- [Day 7 - Data Visualization `ggplot2` & Factors Cheatsheet](https://daseh.org//modules/cheatsheets/Day-7.pdf)
+- [Day 8 - Statistics Cheatsheet](https://daseh.org//modules/cheatsheets/Day-8.pdf)
+- [Day 9 - Functions Cheatsheet](https://daseh.org//modules/cheatsheets/Day-9.pdf)
 - [Additional RStudio "Cheatsheets"](https://www.rstudio.com/resources/cheatsheets/)
 
 </details>
@@ -46,8 +46,8 @@ Here are additional resources to help you on your R journey - either before, dur
 
 <details><summary> <span style = "color: #5383bb;"> **Troubleshooting Guides**</span></summary><br>
 
-- [Guide on when to use quotes or backticks](https://jhudatascience.org/intro_to_r/resources/quotes_vs_backticks.html)
-- [Guide on what functions require pulling values out first](https://jhudatascience.org/intro_to_r/resources/functions_for_vectors.html)
+- [Guide on when to use quotes or backticks](https://daseh.org//resources/quotes_vs_backticks.html)
+- [Guide on what functions require pulling values out first](https://daseh.org//resources/functions_for_vectors.html)
 
 </details>
 

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -89,6 +89,7 @@ hrbr
 HTTPS
 https
 http
+Humphries
 HW
 hydrocodone
 ide
@@ -248,4 +249,3 @@ XLSX
 youtube
 yts
 YTS
-

--- a/resources/quotes_vs_backticks.Rmd
+++ b/resources/quotes_vs_backticks.Rmd
@@ -267,7 +267,7 @@ This is true for URLs or paths.
 
 ```{r message=FALSE, warning=FALSE}
 # Use this
-vacc <- read_csv(file = "http://jhudatascience.org/intro_to_r/data/vaccinations.csv")
+vacc <- read_csv(file = "https://daseh.org/data/vaccinations.csv")
 ```
 
 ### tidyselect helper functions like `contains()`

--- a/syllabus.Rmd
+++ b/syllabus.Rmd
@@ -173,6 +173,8 @@ We would like to create an open, safe, welcoming, diverse, inclusive, intellectu
 
 We strive to be a space in which individual differences are respected, so that each individual can reach their fullest potential.
 
+TODO: Put code of conduct here
+
 <br>
 
 ### Guidelines
@@ -196,4 +198,4 @@ This applies to emails, surveys, Slack, Zoom, office hours, meetings with other 
 
 ### Resources
 
-<Put code of conduct and other resources here>
+TODO: Put other resources here!

--- a/syllabus.Rmd
+++ b/syllabus.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Syllabus"
-output: 
+output:
   html_document
 ---
 
@@ -36,7 +36,7 @@ By the end of the course, students should be comfortable:
 
 <br>
 
-### When 
+### When
 
 - **Dates:** `r config::get("course_dates")` (`r config::get("holiday")`)
 - **Time:** `r config::get("course_time")`
@@ -45,7 +45,7 @@ By the end of the course, students should be comfortable:
 
 ### Where
 
-- **Class Website:** http://jhudatascience.org/intro_to_r/   
+- **Class Website:** https://daseh.org/   
 - **CoursePlus:** `r config::get("courseplus_web")`
 - Course lectures and labs will be online through Zoom
 - Zoom link and Slack link will be emailed to students
@@ -63,16 +63,16 @@ By the end of the course, students should be comfortable:
 ## Course Format
 
 - Each class will consist of 2 or 3 hour-long modules.
-- Each module features a lecture and an R programming lab, where students apply the skills taught in the modules to real data in breakout rooms. 
-- Class sessions will be recorded and later posted. 
-- If you have a question not covered during class, please post it on Slack. This allows everyone to see it. If another student does not answer your question (which we encourage!), we will try to answer it within 24 hours. If you feel uncomfortable posting a question publicly, let a TA or instructor know your question and we will post it for you anonymously. 
+- Each module features a lecture and an R programming lab, where students apply the skills taught in the modules to real data in breakout rooms.
+- Class sessions will be recorded and later posted.
+- If you have a question not covered during class, please post it on Slack. This allows everyone to see it. If another student does not answer your question (which we encourage!), we will try to answer it within 24 hours. If you feel uncomfortable posting a question publicly, let a TA or instructor know your question and we will post it for you anonymously.
 - To get the most out of this class, if possible, we suggest working virtually with a **large monitor or two screens**. This setup allows you to follow along on Zoom while also doing the hands-on coding.  
 - <details><summary> <span style = "color: #5383bb;"> **Please click here for details about using Zoom.**</span></summary>
-      
+
   Zoom + Working Virtually
-  
+
   ***
-  
+
   * Please be aware that there is the option to use closed captioning:
 
   ![closed captioning on zoom](docs/images/CC.png)
@@ -86,7 +86,7 @@ By the end of the course, students should be comfortable:
   ![ask for help](docs/images/help.png)
 
   * For directions on how to change breakout rooms click [here](https://docs.google.com/document/d/1YP1pZF1bIm66_Tl15Y3eHl8pGxNIASD33mKCtGCfQzc/edit?usp=sharing).
-    
+
   ***
   </details>
 
@@ -96,9 +96,7 @@ By the end of the course, students should be comfortable:
 
 Course evaluations are very important for the school to determine what courses to continue to support. It also helps us to improve the course with your feedback.
 
-- Use this link to access the evaluation: https://courseevaluations.jhsph.edu. 
-- Use your JHED ID or  and password to log in. If you do not have a JHED ID, sign in as a “Guest User” using the email provided to create your JHU login during course registration. Please contact JHSPH.courseeval@jhu.edu for assistance.  
-- All non-auditing institute students (whether they are taking courses for credit or not) are eligible to evaluate their courses. 
+TODO: What are the methods for course evaluations???
 
 <br>
 
@@ -108,7 +106,7 @@ Course evaluations are very important for the school to determine what courses t
 
 ### Grading
 
-All assignments are due **`r config::get("final_due_date")`**. 
+All assignments are due **`r config::get("final_due_date")`**.
 
 | **Assignment**       |  **Percent of Grade**|
 |:---------------------|---------------------:|
@@ -131,7 +129,7 @@ You should complete the following:
 | :-------------------------: | :-------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------: |
 | Homework 1                  | [Day 0 Instructions](docs/module_details/day0.html) | [Dataquest](https://app.dataquest.io/login?target-url=%2Fm%2F499%2Fintroduction-to-programming-in-r)                                               |
 | Homework 2                  |                                                     | [Rmd](modules/HW/homework2.Rmd), [HTML](modules/HW/homework2.html), [Key](modules/HW/homework2_Key.Rmd), [Key HTML](modules/HW/homework2_Key.html) |
-| Homework 3                  |                                                     | [Rmd](modules/HW/homework3.Rmd), [HTML](modules/HW/homework3.html), [Key](modules/HW/homework3_Key.Rmd), [Key HTML](modules/HW/homework3_Key.html) | 
+| Homework 3                  |                                                     | [Rmd](modules/HW/homework3.Rmd), [HTML](modules/HW/homework3.html), [Key](modules/HW/homework3_Key.Rmd), [Key HTML](modules/HW/homework3_Key.html) |
 
 <br>
 
@@ -143,7 +141,7 @@ This project should entail:
 - doing some light data cleaning
 - performing some data summarization
 - creating a couple of visualizations
-- doing some very light statistical analysis, like regression or t-tests 
+- doing some very light statistical analysis, like regression or t-tests
 
 You may use public datasets, or your own data for the project. If using your own dataset, **be sure any sensitive information is protected**.
 
@@ -155,7 +153,7 @@ See the [guidelines/instructions](modules/Project_Guidelines/Project_Guidelines.
 
 ### Submission
 
-All assignments are due **`r config::get("final_due_date")`**. 
+All assignments are due **`r config::get("final_due_date")`**.
 
 Submit each assignment to the designated [Drop Box on CoursePlus](`r config::get("courseplus_dropboxes")`).
 
@@ -171,7 +169,7 @@ For example, if you scored 9/10 on an assignment (90%) but turned it in two days
 
 ## Code of Conduct
 
-We would like to create an open, safe, welcoming, diverse, inclusive, intellectually stimulating, and hopefully fun class experience. 
+We would like to create an open, safe, welcoming, diverse, inclusive, intellectually stimulating, and hopefully fun class experience.
 
 We strive to be a space in which individual differences are respected, so that each individual can reach their fullest potential.
 
@@ -192,23 +190,10 @@ We strive to be a space in which individual differences are respected, so that e
 
 This applies to emails, surveys, Slack, Zoom, office hours, meetings with other students, instructors, or TAs.
 
- **Please reach out to a TA or instructor if you witness or experience a violation of the class guidelines or other JHU codes of conduct.**
- 
+ **Please reach out to a TA or instructor if you witness or experience a violation of the class guidelines our codes of conduct.**
+
 <br>
- 
+
 ### Resources
 
-- **JHU Student Code of Conduct:** https://studentaffairs.jhu.edu/policies-guidelines/student-code/  
-- **Hopkins School of Medicine:** https://www.hopkinsmedicine.org/research/resources/offices-policies/OPC/Research_Integrity/som_code_of_conduct_04302020.pdf   
-- **JHSPH Academic Ethics Code:** https://www.jhsph.edu/offices-and-services/student-affairs/resources/student-policies/_documents/academic-ethics-code.pdf  
-
-**The University has developed avenues for reporting and for seeking help including:** 
-
-- JHU Sexual Assault Helpline, 410-516-7333 (confidential)  
-- Campus Safety and Security, 410-516-7777  
-- University Sexual Assault Response and Prevention website  
-- Johns Hopkins Compliance Hotline, 844-SPEAK2US (844-733-2528)  
-- JHU Office of Institutional Equity 410-516-8075 (nonconfidential)   
-- Johns Hopkins Student Assistance Program (JHSAP), 443-287-7000  
-- University Health Services - Mental Health (UHS-MS), 410-955-1892  
-- The Faculty and Staff Assistance Program (FASAP), 443-997-7000  
+<Put code of conduct and other resources here>


### PR DESCRIPTION
## Summary 

This PR is about removing only JHU relevant information from the website since DaSEH is not a JHU branded thing. 

I did this by: 

- Search and replacing `jhudatascience.org/intro_to_r with daseh.org`
- Searching for terms like "hopkins" and "JHU" and removing that content where it was not applicable. 
- On applicable information that probably needs replacements, I put `TODO:`s which I will now also make into GitHub issues. 

## Follow up question 

Will the `jhur` package need to be made into a DASEH flavor for use with this? That would be extra maintenance so it should only be done if it would add value. Alternatively its name could be changed so its clear its used here and at `intro_to_r`. OR nothing needs to be changed and that's fine too. 