### PR TITLE
[Dictionary] add CES and others to dictionary

### DIFF
--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -22,7 +22,10 @@ Boardings
 Bonferroni
 bp
 BSPH
+CalEnviroScreen
 CDS
+CES
+ces
 ChatGPT
 cheatsheet
 circ
@@ -46,6 +49,7 @@ ctrl
 custimization
 customizable
 cwrigh
+daseh
 DaSEH
 DaSEH's
 Dataquest
@@ -74,6 +78,7 @@ fct
 Fewings
 Fleetwood
 forcats
+fredhutch
 freepik
 fwang
 Gardiner

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -93,7 +93,9 @@ ggthemes
 github
 GitHub
 GitHub
+HAA
 Hadley
+Haloacetic
 healthdata
 hoffman
 Hotline

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -153,6 +153,7 @@ NISSANs
 nizovatina
 NonCommercial
 nonconfidential
+NWSS
 obert
 ocs
 OCSdata
@@ -208,6 +209,7 @@ Rtools
 Rupshikha
 Sagar
 Saravanan
+SARS
 Savonen
 setosa
 ShareAlike
@@ -251,6 +253,7 @@ VehBCost
 VehicleAge
 VehOdo
 VehYear
+wastewater
 wb
 Wickham
 Wickham's

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -39,6 +39,7 @@ codeexample
 codesmall
 collegial
 CoursePlus
+Covid
 CoV
 cran
 csavone


### PR DESCRIPTION
Every lab branch is going to have these same spelling issues, so I might as well fix it now. This PR adds the following words to dictionary.txt:

daseh
CalEnviroScreen
CES
ces
fredhutch

