### PR TITLE
[Manipulating_Data] Update data attribution statement in lab

### DIFF
--- a/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd
+++ b/modules/Manipulating_Data_in_R/lab/Manipulating_Data_in_R_Lab.Rmd
@@ -9,7 +9,9 @@ editor_options:
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-Data in this lab comes from the OCS "Exploring CO2 emissions across time" activity (https://www.opencasestudies.org/ocs-bp-co2-emissions/) and the CO Department of Health (https://coepht.colorado.gov/heat-related-illness). Both datasets are available in the `dasehr` package.
+Some data in this lab comes from the OCS "Exploring CO2 emissions across time" activity (https://www.opencasestudies.org/ocs-bp-co2-emissions/. This dataset is available in the `dasehr` package.
+
+Additional data about climate change disasters can be found at "https://daseh.org/data/Yearly_CC_Disasters.csv".
 
 ```{r message=FALSE}
 library(readr)


### PR DESCRIPTION
The data attribution statement at the beginning of the lab had information about a dataset used in a previous version of the activity. This PR updates the statement so it points to the proper datasets.