### PR TITLE
[Subsetting Data] remove dasehr mentions from lecture

### DIFF
--- a/modules/Subsetting_Data_in_R/Subsetting_Data_in_R.Rmd
+++ b/modules/Subsetting_Data_in_R/Subsetting_Data_in_R.Rmd
@@ -352,9 +352,6 @@ The `clean_names` function can intuit what fixes you might need.
 The yearly_co2_emissions dataset contains estimated CO2 emissions for 265 countries between the years 1751 and 2014.
 
 ```{r}
-#library(dasehr)
-#yearly_co2 <- dasehr::yearly_co2_emissions
-# or this:
 yearly_co2 <- 
   read_csv("https://daseh.org/data/Yearly_CO2_Emissions_1000_tonnes.csv")
 ```
@@ -423,9 +420,7 @@ We'll work with the CO heat-related ER visits dataset again.
 This time lets also make it a smaller subset so it is easier for us to see the full dataset as we work through examples. 
 
 ```{r}
-#library(dasehr)
-#er <- CO_heat_ER
-#or this:
+
 #read_csv("https://daseh.org/data/CO_ER_heat_visits.csv")
 set.seed(1234)
 er_30 <-slice_sample(er, n = 30)
@@ -689,10 +684,8 @@ D. `select()` with `&`
 ## Get the data
 
 ```{r}
-#library(dasehr)
-#ER <- CO_heat_ER
-# or this:
-#read_csv("https://daseh.org/data/Colorado_ER_heat_visits.csv")
+
+#er <- read_csv("https://daseh.org/data/Colorado_ER_heat_visits.csv")
 set.seed(1234)
 er_30 <-slice_sample(er, n = 30)
 ```


### PR DESCRIPTION
Looked through the lecture and realized there were still references to the dasehr package, but we haven't introduced it to them (and also, the package hasn't been cleaned up to remove the extra versions of the CO er datasets). This PR removes three references.