### PR TITLE
[Subsetting] testing website rendering of lab key

### DIFF
--- a/modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab_Key.Rmd
+++ b/modules/Subsetting_Data_in_R/lab/Subsetting_Data_in_R_Lab_Key.Rmd
@@ -13,12 +13,11 @@ In this lab you can use the interactive console to explore but please record you
 
 # Part 1
 
-First let's load our packages.
+First let's load our packages. We're going to be using the `dplyr` package, which you can load as part of the `tidyverse` package.
 
 
 ```{r, message = FALSE}
 # don't forget to load the packages that you will need!
-library(dplyr)
 library(tidyverse)
 ```
 


### PR DESCRIPTION
There is a strange error on the html version of the lab key. It's still showing a CES dataset version that has 68 columns, but the dataset was updated to only have 67 columns. The code in the lab, when run locally, loads the updated version of the dataset.

This PR is attempting to figure out what's going on.