### PR TITLE
[Summarization] change dataset name on one lecture slide

### DIFF
--- a/modules/Data_Summarization/Data_Summarization.Rmd
+++ b/modules/Data_Summarization/Data_Summarization.Rmd
@@ -259,7 +259,7 @@ er_grouped %>%
 
 ## Do it in one step: use `%>%` to string these together!
 
-Pipe `CO_heat_ER` into `group_by`, then pipe that into `summarize`:
+Pipe `er` into `group_by`, then pipe that into `summarize`:
 
 ```{r}
 er %>%


### PR DESCRIPTION
I noticed one of the slides still referred to the "CO_heat_ER" dataset. It's now called "er", so this PR changes "CO_heat_ER" to match everything else.