### PR TITLE
tweak to make sure blank lab will render

### DIFF
--- a/modules/Statistics/lab/Statistics_Lab_Key.Rmd
+++ b/modules/Statistics/lab/Statistics_Lab_Key.Rmd
@@ -65,8 +65,8 @@ cor(ces_sub, use = "complete.obs")
 
 Perform a t-test to determine if there is evidence of a difference between low birth weight percentage (`LowBirthWeight`) in Los Angeles census tracts compared to San Diego:
 
-* Create a subset of the data for CaliforniaCounty == "Los Angeles"
-* Create a subset of the data for CaliforniaCounty == "San Diego"
+* Create a subset of the data for `CaliforniaCounty == "Los Angeles"`
+* Create a subset of the data for `CaliforniaCounty == "San Diego"`
 * `pull` the `LowBirthWeight` column for both subsets
 * Use `t.test` to compare the two pulled vectors
 * Print the results using the `tidy` function from the `broom` package

--- a/modules/Statistics/lab/Statistics_Lab_Key.Rmd
+++ b/modules/Statistics/lab/Statistics_Lab_Key.Rmd
@@ -174,6 +174,8 @@ Let's make `LowBirthWeight` into a binary variable, where over 5% low birth weig
 The following code creates a column `weight_cat` with TRUE/FALSE values.
 
 ```{r}
+ces <- read_csv("https://daseh.org/data/CalEnviroScreen_data.csv")
+
 ces_bw <- 
   ces %>% 
   mutate(weight_cat = LowBirthWeight > 5)


### PR DESCRIPTION
Resolving [this](https://github.com/fhdsl/DaSEH/actions/runs/11259519666/job/31308709802):

```
Error:
! object 'ces' not found
Backtrace:
 1. ces %>% mutate(weight_cat = LowBirthWeight > 5)
 2. dplyr::mutate(., weight_cat = LowBirthWeight > 5)

Quitting from lines 144-147 [unnamed-chunk-2] (Statistics_Lab.Rmd)
```

Basically the blank isn't rendering because one of the answers was loading the data. Added an import step to the code that's there.