### PR TITLE
Update URL for CC disasters data source

### DIFF
--- a/modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab_Key.Rmd
+++ b/modules/Esquisse_Data_Visualization/lab/Esquisse_Data_Visualization_Lab_Key.Rmd
@@ -83,7 +83,7 @@ Launch Esquisse on any selection of the following datasets we have worked with b
 ```{r}
 co2 <- read_csv("https://daseh.org/data/Yearly_CO2_Emissions_1000_tonnes.csv")
 
-cc <- read_csv("https://daseh.org/data/Yearly_CC_Disasters.csv")
+cc <- read_csv("https://daseh.org/data/Yearly_CC_disasters_total_affected.csv")
 
 nitrate <- read_csv(file = "https://daseh.org/data/Nitrate_Exposure_for_WA_Public_Water_Systems_byquarter_data.csv")
 


### PR DESCRIPTION
Noticed this url was out-of-date for one of the urls in the esquisse lab when I was working with the files for the guide (couldn't render it). Looks like we renamed it recently